### PR TITLE
jsonb: fix a wrong how to use jsonb index

### DIFF
--- a/expected/jsonb/count/count.out
+++ b/expected/jsonb/count/count.out
@@ -1,0 +1,11 @@
+CREATE TABLE logs (
+  record jsonb
+);
+CREATE INDEX pgroonga_index ON logs USING pgroonga (record);
+SET enable_seqscan = false;
+SELECT COUNT(*) FROM logs;
+ count 
+-------
+     0
+(1 row)
+DROP TABLE logs;

--- a/sql/jsonb/count/count.sql
+++ b/sql/jsonb/count/count.sql
@@ -1,0 +1,9 @@
+CREATE TABLE logs (
+  record jsonb
+);
+
+CREATE INDEX pgroonga_index ON logs USING pgroonga (record);
+
+SET enable_seqscan = false;
+SELECT COUNT(*) FROM logs;
+DROP TABLE logs;

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5940,8 +5940,26 @@ PGrnIsRangeSearchable(IndexScanDesc scan)
 		grn_obj *indexColumn;
 		grn_obj *lexicon;
 		grn_obj *tokenizer;
+		unsigned int nthAttribute = 0;
 
-		indexColumn = PGrnLookupIndexColumn(scan->indexRelation, 0, ERROR);
+		TupleDesc desc = RelationGetDescr(scan->indexRelation);
+		Form_pg_attribute attribute = TupleDescAttr(desc, nthAttribute);
+
+		if (PGrnAttributeIsJSONB(attribute->atttypid))
+		{
+			grn_obj *jsonValuesTable;
+			jsonValuesTable =
+				PGrnJSONBLookupValuesTable(scan->indexRelation,
+										   nthAttribute,
+										   ERROR);
+			indexColumn = PGrnLookupColumn(jsonValuesTable,
+										   PGrnIndexColumnName,
+										   ERROR);
+		}
+		else
+		{
+			indexColumn = PGrnLookupIndexColumn(scan->indexRelation, nthAttribute, ERROR);
+		}
 		lexicon = grn_column_table(ctx, indexColumn);
 		tokenizer = grn_obj_get_info(ctx, lexicon, GRN_INFO_DEFAULT_TOKENIZER,
 									 NULL);


### PR DESCRIPTION
TODO:implementation

PGroonga occurs error when executing `SELECT COUNT(*) FROM xxx` if we set JSONB index and nothing `WHERE` phrase.

```sql
CREATE TABLE logs (
  record jsonb
);

CREATE INDEX pgroonga_index ON logs USING pgroonga (record);

SET enable_seqscan = false;
SELECT COUNT(*) FROM logs;

ERROR:  pgroonga: object isn't found: <Lexiconxxxxx_0.index>
```