### PR TITLE
package centos: fix a parse error for pgdg-redhat-all.repo

### DIFF
--- a/packages/postgresql-10-pgroonga/yum/centos-6/Dockerfile
+++ b/packages/postgresql-10-pgroonga/yum/centos-6/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     groonga-devel \

--- a/packages/postgresql-10-pgroonga/yum/centos-7/Dockerfile
+++ b/packages/postgresql-10-pgroonga/yum/centos-7/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     ccache \

--- a/packages/postgresql-11-pgroonga/yum/centos-6/Dockerfile
+++ b/packages/postgresql-11-pgroonga/yum/centos-6/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     groonga-devel \

--- a/packages/postgresql-11-pgroonga/yum/centos-7/Dockerfile
+++ b/packages/postgresql-11-pgroonga/yum/centos-7/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     centos-release-scl \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     ccache \

--- a/packages/postgresql-12-pgroonga/yum/centos-6/Dockerfile
+++ b/packages/postgresql-12-pgroonga/yum/centos-6/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     groonga-devel \

--- a/packages/postgresql-12-pgroonga/yum/centos-7/Dockerfile
+++ b/packages/postgresql-12-pgroonga/yum/centos-7/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     centos-release-scl \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     ccache \

--- a/packages/postgresql-12-pgroonga/yum/centos-8/Dockerfile
+++ b/packages/postgresql-12-pgroonga/yum/centos-8/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   dnf module -y ${quiet} disable postgresql && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=PowerTools -y ${quiet} \

--- a/packages/postgresql-9.5-pgroonga/yum/centos-6/Dockerfile
+++ b/packages/postgresql-9.5-pgroonga/yum/centos-6/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     groonga-devel \

--- a/packages/postgresql-9.5-pgroonga/yum/centos-7/Dockerfile
+++ b/packages/postgresql-9.5-pgroonga/yum/centos-7/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     ccache \

--- a/packages/postgresql-9.6-pgroonga/yum/centos-6/Dockerfile
+++ b/packages/postgresql-9.6-pgroonga/yum/centos-6/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     groonga-devel \

--- a/packages/postgresql-9.6-pgroonga/yum/centos-7/Dockerfile
+++ b/packages/postgresql-9.6-pgroonga/yum/centos-7/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     https://packages.groonga.org/centos/groonga-release-latest.noarch.rpm \
     epel-release && \
+  sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   yum groupinstall -y ${quiet} "Development Tools" && \
   yum install -y ${quiet} \
     ccache \


### PR DESCRIPTION
This fix is only temporary.
This bug is fixing upstream now.