### PR TITLE
wal: release a lock every time that a page in a block is initialized

### DIFF
--- a/expected/function/wal-truncate/many-records.out
+++ b/expected/function/wal-truncate/many-records.out
@@ -1,0 +1,19 @@
+SET pgroonga.enable_wal = yes;
+CREATE TABLE memos (
+  content text
+);
+INSERT INTO memos
+SELECT string_agg(str, '') 
+  FROM 
+  (SELECT chr(12449 + (random() * 1000)::int % 85 ) as str , i 
+    FROM  generate_series(1,20) length, generate_series(1,100000) num(i)
+   )t
+   GROUP BY i;
+CREATE INDEX pgrn_memos_index ON memos USING PGroonga (content);
+SELECT pgroonga_wal_truncate();
+ pgroonga_wal_truncate 
+-----------------------
+                  1397
+(1 row)
+
+DROP TABLE memos;

--- a/expected/function/wal-truncate/many-records.out
+++ b/expected/function/wal-truncate/many-records.out
@@ -3,17 +3,13 @@ CREATE TABLE memos (
   content text
 );
 INSERT INTO memos
-SELECT string_agg(str, '') 
-  FROM 
-  (SELECT chr(12449 + (random() * 1000)::int % 85 ) as str , i 
-    FROM  generate_series(1,20) length, generate_series(1,100000) num(i)
-   )t
-   GROUP BY i;
+SELECT clock_timestamp()::text
+  FROM generate_series(1, 50000);
 CREATE INDEX pgrn_memos_index ON memos USING PGroonga (content);
 SELECT pgroonga_wal_truncate();
  pgroonga_wal_truncate 
 -----------------------
-                  1397
+                   546
 (1 row)
 
 DROP TABLE memos;

--- a/sql/function/wal-truncate/many-records.sql
+++ b/sql/function/wal-truncate/many-records.sql
@@ -1,0 +1,18 @@
+SET pgroonga.enable_wal = yes;
+
+CREATE TABLE memos (
+  content text
+);
+
+INSERT INTO memos
+SELECT string_agg(str, '') 
+  FROM 
+  (SELECT chr(12449 + (random() * 1000)::int % 85 ) as str , i 
+    FROM  generate_series(1,20) length, generate_series(1,100000) num(i)
+   )t
+   GROUP BY i;
+
+CREATE INDEX pgrn_memos_index ON memos USING PGroonga (content);
+SELECT pgroonga_wal_truncate();
+
+DROP TABLE memos;

--- a/sql/function/wal-truncate/many-records.sql
+++ b/sql/function/wal-truncate/many-records.sql
@@ -5,12 +5,8 @@ CREATE TABLE memos (
 );
 
 INSERT INTO memos
-SELECT string_agg(str, '') 
-  FROM 
-  (SELECT chr(12449 + (random() * 1000)::int % 85 ) as str , i 
-    FROM  generate_series(1,20) length, generate_series(1,100000) num(i)
-   )t
-   GROUP BY i;
+SELECT clock_timestamp()::text
+  FROM generate_series(1, 50000);
 
 CREATE INDEX pgrn_memos_index ON memos USING PGroonga (content);
 SELECT pgroonga_wal_truncate();

--- a/src/pgrn-wal.c
+++ b/src/pgrn-wal.c
@@ -2147,7 +2147,6 @@ PGrnWALTruncate(Relation index)
 	int64_t nTruncatedBlocks = 0;
 	BlockNumber i;
 	BlockNumber nBlocks;
-	Buffer *buffers;
 	GenericXLogState *state;
 
 	LockRelation(index, PGrnWALLockMode());
@@ -2157,8 +2156,6 @@ PGrnWALTruncate(Relation index)
 		UnlockRelation(index, PGrnWALLockMode());
 		return 0;
 	}
-
-	buffers = palloc(sizeof(Buffer) * nBlocks);
 
 	state = GenericXLogStart(index);
 
@@ -2170,10 +2167,10 @@ PGrnWALTruncate(Relation index)
 		buffer = PGrnWALReadLockedBuffer(index,
 										 PGRN_WAL_META_PAGE_BLOCK_NUMBER,
 										 BUFFER_LOCK_EXCLUSIVE);
-		buffers[0] = buffer;
 		page = GenericXLogRegisterBuffer(state, buffer, GENERIC_XLOG_FULL_IMAGE);
 		pageSpecial = (PGrnWALMetaPageSpecial *) PageGetSpecialPointer(page);
 		pageSpecial->next = PGRN_WAL_META_PAGE_BLOCK_NUMBER + 1;
+		UnlockReleaseBuffer(buffer);
 
 		nTruncatedBlocks++;
 	}
@@ -2184,7 +2181,6 @@ PGrnWALTruncate(Relation index)
 		Page page;
 
 		buffer = PGrnWALReadLockedBuffer(index, i, BUFFER_LOCK_EXCLUSIVE);
-		buffers[i] = buffer;
 		if (nTruncatedBlocks >= MAX_GENERIC_XLOG_PAGES)
 		{
 			GenericXLogFinish(state);
@@ -2192,17 +2188,11 @@ PGrnWALTruncate(Relation index)
 		}
 		page = GenericXLogRegisterBuffer(state, buffer, GENERIC_XLOG_FULL_IMAGE);
 		PageInit(page, BLCKSZ, 0);
+		UnlockReleaseBuffer(buffer);
 
 		nTruncatedBlocks++;
 	}
-
 	GenericXLogFinish(state);
-
-	for (i = 0; i < nBlocks; i++)
-	{
-		UnlockReleaseBuffer(buffers[i]);
-	}
-	pfree(buffers);
 
 	PGrnIndexStatusSetWALAppliedPosition(index,
 										 PGRN_WAL_META_PAGE_BLOCK_NUMBER + 1,


### PR DESCRIPTION
GitHub: fix #150 Reported by BiscuitsColonel Thanks!!!

PostgreSQL occurs PANIC if we truncate PGroonga's WAL that it includes many modifications.
Because the number of Locks that we require for truncating WAL is limited.

The maximum number of these locks is 200.

See:
https://github.com/postgres/postgres/blob/REL_13_1/src/backend/storage/lmgr/lwlock.c#L208

The loop of PGrnWALTruncate() may very well run more than 200 times.
So, we release locks every GenericXLogFinish().