### PR TITLE
ci linux: Remove accidental quotes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,7 +76,7 @@ jobs:
             component=main
           fi
           sudo tee /etc/apt/sources.list.d/pgdg.list <<APT_SOURCE
-          deb http://apt.postgresql.org/pub/repos/apt "$suite" "$component"
+          deb http://apt.postgresql.org/pub/repos/apt $suite $component
           APT_SOURCE
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt update


### PR DESCRIPTION
Apparently APT accepted these, but that’s not documented so we shouldn’t rely on it.