### PR TITLE
ci: enable tests that have failed temporarily due to PostgreSQL's bug

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -110,12 +110,6 @@ jobs:
           if [ "$(echo "${{ matrix.postgresql-version }} < 13" | bc)" -eq 1 ]; then
             rm sql/full-text-search/text/single/declarative-partitioning.sql
           fi
-          # TODO: PostgreSQL 14.3, 13.7, 12.11, 11.16 and 10.21 will fix
-          # PostgreSQL bug of them.
-          if [ "$(echo "${{ matrix.postgresql-version }} < 15" | bc)" -eq 1 ]; then
-            rm sql/index-only-scan/count-star-large.sql
-            rm sql/jsonb/count-star/indexscan.sql
-          fi
           if [ "${GROONGA_MASTER}" = "yes" ]; then
             # TODO: We don't know why this case doesn't use parallel scan...
             rm sql/full-text-search/text/single/declarative-partitioning.sql

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -214,12 +214,6 @@ jobs:
           if (${{ matrix.postgresql-version-major }} -lt 13) {
             Remove-Item sql\full-text-search\text\single\declarative-partitioning.sql
           }
-          # TODO: PostgreSQL 14.3, 13.7, 12.11, 11.16 and 10.21 will fix
-          # PostgreSQL bug of them.
-          if (${{ matrix.postgresql-version-major }} -lt 15) {
-            Remove-Item sql\index-only-scan\count-star-large.sql
-            Remove-Item sql\jsonb\count-star\indexscan.sql
-          }
           ruby test\prepare.rb > schedule
           $Env:PG_REGRESS_DIFF_OPTS = "-u"
           ..\pgsql\bin\pg_regress `

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -98,12 +98,6 @@ fi
 if [ "$((${postgresql_version} < 13))" -eq 1 ]; then
   rm sql/full-text-search/text/single/declarative-partitioning.sql
 fi
-# TODO: PostgreSQL 14.3, 13.7, 12.11, 11.16 and 10.21 will fix
-# PostgreSQL bug of them.
-if [ "$((${postgresql_version} < 15))" -eq 1 ]; then
-  rm sql/index-only-scan/count-star-large.sql
-  rm sql/jsonb/count-star/indexscan.sql
-fi
 ruby /host/test/prepare.rb > schedule
 PG_REGRESS_DIFF_OPTS="-u"
 if diff --help | grep -q color; then

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -130,12 +130,6 @@ case "${os}" in
     if [ "$((${postgresql_version} < 13))" -eq 1 ]; then
       rm sql/full-text-search/text/single/declarative-partitioning.sql
     fi
-    # TODO: PostgreSQL 14.3, 13.7, 12.11, 11.16 and 10.21 will fix
-    # PostgreSQL bug of them.
-    if [ "$((${postgresql_version} < 15))" -eq 1 ]; then
-      rm sql/index-only-scan/count-star-large.sql
-      rm sql/jsonb/count-star/indexscan.sql
-    fi
     ;;
   fedora)
     # Require Groonga 10.1.0 or later.


### PR DESCRIPTION
Because PostgreSQL 14.3, 13.7, 12.11, 11.16, and 10.21 have been already released.