### PR TITLE
ci: use ubuntu-22.10 only when we execute tests for PostgreSQL 15

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,8 +85,8 @@ jobs:
           if [ "${POSTGRESQL_UNRELEASED}" = "yes" ]; then
             suite="$(lsb_release -cs)-pgdg-testing"
             sudo tee /etc/apt/sources.list.d/pgdg-testing.list <<APT_SOURCE
-            deb http://apt.postgresql.org/pub/repos/apt ${suite} ${{ matrix.postgresql-version }}
-            APT_SOURCE
+          deb http://apt.postgresql.org/pub/repos/apt ${suite} ${{ matrix.postgresql-version }}
+          APT_SOURCE
           fi
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt update

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,37 +29,29 @@ jobs:
         include:
           - label: PostgreSQL 10
             postgresql-version: "10"
-            runs-os: ubuntu-20.04
           - label: PostgreSQL 11
             postgresql-version: "11"
-            runs-os: ubuntu-20.04
           - label: PostgreSQL 12
             postgresql-version: "12"
-            runs-os: ubuntu-20.04
           - label: PostgreSQL 13
             postgresql-version: "13"
-            runs-os: ubuntu-20.04
           - label: PostgreSQL 14
             postgresql-version: "14"
-            runs-os: ubuntu-20.04
           - label: PostgreSQL 14 with Groonga master
             groonga-master: "yes"
             postgresql-version: "14"
-            runs-os: ubuntu-20.04
           - label: PostgreSQL 15 snapshot
             postgresql-unreleased: "yes"
             postgresql-version: "15"
-            runs-os: ubuntu-22.10
           - label: PostgreSQL 15 snapshot with Groonga master
             groonga-master: "yes"
             postgresql-unreleased: "yes"
             postgresql-version: "15"
-            runs-os: ubuntu-22.10
     env:
       GROONGA_MASTER: ${{ matrix.groonga-master }}
       POSTGRESQL_UNRELEASED: ${{ matrix.postgresql-unreleased }}
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}/pgroonga-benchmark/Gemfile
-    runs-on: ${{ matrix.runs-os }}
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,20 +78,19 @@ jobs:
       - name: Install PostgreSQL
         run: |
           sudo apt -y -V purge '^postgresql'
-          ls -lah /etc/apt/sources.list.d/
+          suite=$(lsb_release -cs)-pgdg
+          sudo tee /etc/apt/sources.list.d/pgdg.list <<APT_SOURCE
+          deb http://apt.postgresql.org/pub/repos/apt ${suite} main
+          APT_SOURCE
           if [ "${POSTGRESQL_UNRELEASED}" = "yes" ]; then
             suite="$(lsb_release -cs)-pgdg-testing"
-            component=${{ matrix.postgresql-version }}
-          else
-            suite="$(lsb_release -cs)-pgdg"
-            component=main
+            sudo tee /etc/apt/sources.list.d/pgdg-testing.list <<APT_SOURCE
+            deb http://apt.postgresql.org/pub/repos/apt ${suite} ${{ matrix.postgresql-version }}
+            APT_SOURCE
           fi
-          sudo tee /etc/apt/sources.list.d/pgdg.list <<APT_SOURCE
-          deb http://apt.postgresql.org/pub/repos/apt $suite $component
-          APT_SOURCE
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo apt update
-          sudo apt -y -V install \
+          sudo apt -y -V -t ${suite} install \
             postgresql-${{ matrix.postgresql-version }} \
             postgresql-server-dev-${{ matrix.postgresql-version }}
           if [ ${{ matrix.postgresql-version }} -eq 15 ]; then

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,29 +29,37 @@ jobs:
         include:
           - label: PostgreSQL 10
             postgresql-version: "10"
+            runs-os: ubuntu-20.04
           - label: PostgreSQL 11
             postgresql-version: "11"
+            runs-os: ubuntu-20.04
           - label: PostgreSQL 12
             postgresql-version: "12"
+            runs-os: ubuntu-20.04
           - label: PostgreSQL 13
             postgresql-version: "13"
+            runs-os: ubuntu-20.04
           - label: PostgreSQL 14
             postgresql-version: "14"
+            runs-os: ubuntu-20.04
           - label: PostgreSQL 14 with Groonga master
             groonga-master: "yes"
             postgresql-version: "14"
+            runs-os: ubuntu-20.04
           - label: PostgreSQL 15 snapshot
             postgresql-unreleased: "yes"
             postgresql-version: "15"
+            runs-os: ubuntu-22.10
           - label: PostgreSQL 15 snapshot with Groonga master
             groonga-master: "yes"
             postgresql-unreleased: "yes"
             postgresql-version: "15"
+            runs-os: ubuntu-22.10
     env:
       GROONGA_MASTER: ${{ matrix.groonga-master }}
       POSTGRESQL_UNRELEASED: ${{ matrix.postgresql-unreleased }}
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}/pgroonga-benchmark/Gemfile
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.runs-os }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Because PostgreSQL 15 depends postgresql-common (>= 241~).
However, the version of postgresql-common on Ubuntu 20.04 is 214ubuntu0.1.