### PR TITLE
ci: don't use libpq-devel for PostgreSQL 13 on Amazon Linux 2

### DIFF
--- a/packages/postgresql-13-pgroonga/yum/amazon-linux-2/Dockerfile
+++ b/packages/postgresql-13-pgroonga/yum/amazon-linux-2/Dockerfile
@@ -16,7 +16,6 @@ RUN \
     ccache \
     clang \
     groonga-devel \
-    libpq-devel \
     llvm \
     msgpack-devel \
     postgresql-server-devel \

--- a/packages/yum/postgresql-pgroonga.spec.in
+++ b/packages/yum/postgresql-pgroonga.spec.in
@@ -34,7 +34,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 BuildRequires:	groonga-devel >= @GROONGA_VERSION@
 BuildRequires:	msgpack-devel
 %if %{is_amazon_linux}
-  %if %{pg_package_version != 13}
+  %if (%{pg_package_version} != 13)
 BuildRequires: libpq-devel >= %{pg_package_version}, libpq-devel < %(expr %{pg_package_version} + 1)
   %endif
 BuildRequires:	postgresql-server-devel >= %{pg_package_version}, postgresql-server-devel < %(expr %{pg_package_version} + 1)

--- a/packages/yum/postgresql-pgroonga.spec.in
+++ b/packages/yum/postgresql-pgroonga.spec.in
@@ -35,7 +35,7 @@ BuildRequires:	groonga-devel >= @GROONGA_VERSION@
 BuildRequires:	msgpack-devel
 %if %{is_amazon_linux}
   %if (%{pg_package_version} != 13)
-BuildRequires: libpq-devel >= %{pg_package_version}, libpq-devel < %(expr %{pg_package_version} + 1)
+BuildRequires:  libpq-devel >= %{pg_package_version}, libpq-devel < %(expr %{pg_package_version} + 1)
   %endif
 BuildRequires:	postgresql-server-devel >= %{pg_package_version}, postgresql-server-devel < %(expr %{pg_package_version} + 1)
 %else

--- a/packages/yum/postgresql-pgroonga.spec.in
+++ b/packages/yum/postgresql-pgroonga.spec.in
@@ -34,7 +34,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 BuildRequires:	groonga-devel >= @GROONGA_VERSION@
 BuildRequires:	msgpack-devel
 %if %{is_amazon_linux}
-  %if (%{pg_package_version} != 13)
+  %if %{pg_package_version} != 13
 BuildRequires:  libpq-devel >= %{pg_package_version}, libpq-devel < %(expr %{pg_package_version} + 1)
   %endif
 BuildRequires:	postgresql-server-devel >= %{pg_package_version}, postgresql-server-devel < %(expr %{pg_package_version} + 1)

--- a/packages/yum/postgresql-pgroonga.spec.in
+++ b/packages/yum/postgresql-pgroonga.spec.in
@@ -34,6 +34,9 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 BuildRequires:	groonga-devel >= @GROONGA_VERSION@
 BuildRequires:	msgpack-devel
 %if %{is_amazon_linux}
+  %if %{pg_package_version != 13}
+BuildRequires: libpq-devel >= %{pg_package_version}, libpq-devel < %(expr %{pg_package_version} + 1)
+  %endif
 BuildRequires:	postgresql-server-devel >= %{pg_package_version}, postgresql-server-devel < %(expr %{pg_package_version} + 1)
 %else
 BuildRequires:	postgresql%{pg_package_version}-devel

--- a/packages/yum/postgresql-pgroonga.spec.in
+++ b/packages/yum/postgresql-pgroonga.spec.in
@@ -34,7 +34,6 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 BuildRequires:	groonga-devel >= @GROONGA_VERSION@
 BuildRequires:	msgpack-devel
 %if %{is_amazon_linux}
-BuildRequires:	libpq-devel >= %{pg_package_version}, libpq-devel < %(expr %{pg_package_version} + 1)
 BuildRequires:	postgresql-server-devel >= %{pg_package_version}, postgresql-server-devel < %(expr %{pg_package_version} + 1)
 %else
 BuildRequires:	postgresql%{pg_package_version}-devel

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -63,7 +63,7 @@ echo "::group::Install packages for test"
 
 case ${os} in
   amazon-linux)
-    if [ "$((${postgresql_version} != 13))" -eq 1 ]; then
+    if [ ${postgresql_version} -ne 13 ]; then
       ${DNF} install -y libpq-devel
     fi
     ${DNF} install -y postgresql-server-devel
@@ -125,10 +125,10 @@ cp -a \
 cd /tmp
 case "${os}" in
   almalinux|amazon-linux|centos)
-    if [ "$((${postgresql_version} < 11))" -eq 1 ]; then
+    if [ ${postgresql_version} -lt 11 ]; then
       rm sql/index-only-scan/include.sql
     fi
-    if [ "$((${postgresql_version} < 13))" -eq 1 ]; then
+    if [ ${postgresql_version} -lt 13 ]; then
       rm sql/full-text-search/text/single/declarative-partitioning.sql
     fi
     ;;

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -63,8 +63,10 @@ echo "::group::Install packages for test"
 
 case ${os} in
   amazon-linux)
-    ${DNF} install -y \
-           postgresql-server-devel
+    if [ "$((${postgresql_version} != 13))" -eq 1 ]; then
+      install -y libpq-devel
+    fi
+    ${DNF} install -y postgresql-server-devel
     pg_config=pg_config
     groonga_token_filter_stem_package_name=groonga-token-filter-stem
     ;;

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -64,7 +64,6 @@ echo "::group::Install packages for test"
 case ${os} in
   amazon-linux)
     ${DNF} install -y \
-           libpq-devel \
            postgresql-server-devel
     pg_config=pg_config
     groonga_token_filter_stem_package_name=groonga-token-filter-stem

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -64,7 +64,7 @@ echo "::group::Install packages for test"
 case ${os} in
   amazon-linux)
     if [ "$((${postgresql_version} != 13))" -eq 1 ]; then
-      install -y libpq-devel
+      ${DNF} install -y libpq-devel
     fi
     ${DNF} install -y postgresql-server-devel
     pg_config=pg_config


### PR DESCRIPTION
`pg_config` is provided by `postgresql-private-devel` only for PostgreSQL 13 on Amazon Linux 2.
`pg_config` is provided by `libpq-devel` for others.
So `libpq-devel` isn't needed only for PostgreSQL 13 on Amazon Linux 2.