### PR TITLE
packages: add support for Ubuntu 22.04 (Jammy Jellyfish) with PostgreSQL PGDG package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,6 +30,8 @@ jobs:
           - postgresql-13-pgdg-pgroonga-ubuntu-bionic-arm64
           - postgresql-13-pgdg-pgroonga-ubuntu-focal
           - postgresql-13-pgdg-pgroonga-ubuntu-focal-arm64
+          - postgresql-13-pgdg-pgroonga-ubuntu-jammy
+          - postgresql-13-pgdg-pgroonga-ubuntu-jammy-arm64
           - postgresql-13-pgdg-pgroonga-almalinux-8
           - postgresql-13-pgdg-pgroonga-centos-7
           - postgresql-13-pgroonga-amazon-linux-2
@@ -41,6 +43,8 @@ jobs:
           - postgresql-12-pgdg-pgroonga-ubuntu-bionic-arm64
           - postgresql-12-pgdg-pgroonga-ubuntu-focal
           - postgresql-12-pgdg-pgroonga-ubuntu-focal-arm64
+          - postgresql-12-pgdg-pgroonga-ubuntu-jammy
+          - postgresql-12-pgdg-pgroonga-ubuntu-jammy-arm64
           - postgresql-12-pgdg-pgroonga-almalinux-8
           - postgresql-12-pgdg-pgroonga-centos-7
           - postgresql-12-pgroonga-amazon-linux-2
@@ -49,11 +53,15 @@ jobs:
           - postgresql-11-pgdg-pgroonga-ubuntu-bionic-arm64
           - postgresql-11-pgdg-pgroonga-ubuntu-focal
           - postgresql-11-pgdg-pgroonga-ubuntu-focal-arm64
+          - postgresql-11-pgdg-pgroonga-ubuntu-jammy
+          - postgresql-11-pgdg-pgroonga-ubuntu-jammy-arm64
           - postgresql-11-pgroonga-centos-7
           - postgresql-10-pgdg-pgroonga-ubuntu-bionic
           - postgresql-10-pgdg-pgroonga-ubuntu-bionic-arm64
           - postgresql-10-pgdg-pgroonga-ubuntu-focal
           - postgresql-10-pgdg-pgroonga-ubuntu-focal-arm64
+          - postgresql-10-pgdg-pgroonga-ubuntu-jammy
+          - postgresql-10-pgdg-pgroonga-ubuntu-jammy-arm64
           - postgresql-10-pgdg-pgroonga-centos-7
           - postgresql-10-pgroonga-centos-7
           # Groonga 11.0.5 or later is required

--- a/packages/postgresql-10-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-10-pgdg-pgroonga/Rakefile
@@ -11,6 +11,8 @@ class PostgreSQL10PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
       "ubuntu-bionic-arm64",
       "ubuntu-focal",
       "ubuntu-focal-arm64",
+      "ubuntu-jammy",
+      "ubuntu-jammy-arm64",
     ]
   end
 

--- a/packages/postgresql-10-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-10-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,0 +1,1 @@
+arm64v8/ubuntu:jammy

--- a/packages/postgresql-10-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/postgresql-10-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
@@ -1,0 +1,38 @@
+ARG FROM=ubuntu:jammy
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    gnupg \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y universe && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" > \
+    /etc/apt/sources.list.d/pgdg.list && \
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+    apt-key add - && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    libmsgpack-dev \
+    pkg-config \
+    postgresql-server-dev-10 && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN { \
+      echo "DEBUILD_LINTIAN=no"; \
+    } > ~/.devscripts

--- a/packages/postgresql-11-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-11-pgdg-pgroonga/Rakefile
@@ -11,6 +11,8 @@ class PostgreSQL11PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
       "ubuntu-bionic-arm64",
       "ubuntu-focal",
       "ubuntu-focal-arm64",
+      "ubuntu-jammy",
+      "ubuntu-jammy-arm64",
     ]
   end
 

--- a/packages/postgresql-11-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-11-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,0 +1,1 @@
+arm64v8/ubuntu:jammy

--- a/packages/postgresql-11-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/postgresql-11-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
@@ -1,0 +1,38 @@
+ARG FROM=ubuntu:jammy
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    gnupg \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y universe && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" > \
+    /etc/apt/sources.list.d/pgdg.list && \
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+    apt-key add - && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    libmsgpack-dev \
+    pkg-config \
+    postgresql-server-dev-11 && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN { \
+      echo "DEBUILD_LINTIAN=no"; \
+    } > ~/.devscripts

--- a/packages/postgresql-12-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-12-pgdg-pgroonga/Rakefile
@@ -13,6 +13,8 @@ class PostgreSQL12PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
       "ubuntu-bionic-arm64",
       "ubuntu-focal",
       "ubuntu-focal-arm64",
+      "ubuntu-jammy",
+      "ubuntu-jammy-arm64",
     ]
   end
 

--- a/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,0 +1,1 @@
+arm64v8/ubuntu:jammy

--- a/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
@@ -1,0 +1,38 @@
+ARG FROM=ubuntu:jammy
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    gnupg \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y universe && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" > \
+    /etc/apt/sources.list.d/pgdg.list && \
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+    apt-key add - && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    libmsgpack-dev \
+    pkg-config \
+    postgresql-server-dev-12 && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN { \
+      echo "DEBUILD_LINTIAN=no"; \
+    } > ~/.devscripts

--- a/packages/postgresql-13-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-13-pgdg-pgroonga/Rakefile
@@ -13,6 +13,8 @@ class PostgreSQL13PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
       "ubuntu-bionic-arm64",
       "ubuntu-focal",
       "ubuntu-focal-arm64",
+      "ubuntu-jammy",
+      "ubuntu-jammy-arm64",
     ]
   end
 

--- a/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,0 +1,1 @@
+arm64v8/ubuntu:jammy

--- a/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
+++ b/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-jammy/Dockerfile
@@ -1,0 +1,38 @@
+ARG FROM=ubuntu:jammy
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    gnupg \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y universe && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main" > \
+    /etc/apt/sources.list.d/pgdg.list && \
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+    apt-key add - && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    libmsgpack-dev \
+    pkg-config \
+    postgresql-server-dev-13 && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN { \
+      echo "DEBUILD_LINTIAN=no"; \
+    } > ~/.devscripts

--- a/packages/postgresql-14-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-14-pgdg-pgroonga/Rakefile
@@ -13,6 +13,8 @@ class PostgreSQL14PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
       "ubuntu-bionic-arm64",
       "ubuntu-focal",
       "ubuntu-focal-arm64",
+      "ubuntu-jammy",
+      "ubuntu-jammy-arm64",
     ]
   end
 


### PR DESCRIPTION
I support PostgreSQL 10 - 14 PGDG packages on Ubuntu 22.04.

GitHub #228.
Reported by sousuke0422. Thanks!!!