### PR TITLE
ci packages: use latest archive instead of latest repository

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -121,9 +121,9 @@ jobs:
       - name: Clone dependencies
         run: |
           cd ..
-          git clone --depth 1 https://github.com/groonga/groonga.git
-          cd groonga
-          git submodule update --init --force --recursive --depth 1
+          wget https://packages.groonga.org/source/groonga/groonga-latest.tar.gz
+          mkdir groonga
+          tar -zxvf groonga-latest.tar.gz -C groonga --strip-components 1
       - name: Download archive
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -118,7 +118,7 @@ jobs:
             ruby
           sudo gem install bundler
           bundle install
-      - name: Clone dependencies
+      - name: Download dependencies
         run: |
           cd ..
           wget https://packages.groonga.org/source/groonga/groonga-latest.tar.gz


### PR DESCRIPTION
Use the latest archive instead of the latest repository.