### PR TITLE
Use RELKIND_HAS_PARTITIONS only PostgreSQL 15 or later

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -263,3 +263,12 @@ typedef Oid PGrnRelFileNumber;
 #	define pgrn_pg_class_ownercheck(relationOid, userOid)	\
 	pg_class_ownercheck((relationOid), (userOid))
 #endif
+
+#if PG_VERSION_NUM >= 150000
+#	define PGRN_RELKIND_HAS_PARTITIONS(relkind)	\
+	RELKIND_HAS_PARTITIONS(relkind)
+#else
+#	define PGRN_RELKIND_HAS_PARTITIONS(relkind)	\
+	((relkind) == RELKIND_PARTITIONED_TABLE ||	\
+	 (relkind) == RELKIND_PARTITIONED_INDEX)
+#endif

--- a/src/pgrn-wal.c
+++ b/src/pgrn-wal.c
@@ -2198,7 +2198,7 @@ pgroonga_wal_apply_all(PG_FUNCTION_ARGS)
 			RelationClose(index);
 			continue;
 		}
-		if (RELKIND_HAS_PARTITIONS(index->rd_rel->relkind))
+		if (PGRN_RELKIND_HAS_PARTITIONS(index->rd_rel->relkind))
 		{
 			RelationClose(index);
 			continue;


### PR DESCRIPTION
Because RELKIND_HAS_PARTITIONS is added since PostgreSQL 15.
See: https://github.com/postgres/postgres/commit/37b2764593c073ca61c2baebd7d85666e553928b