### PR TITLE
tools: enable powertools repository for AlmaLinux 8

### DIFF
--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -20,6 +20,10 @@ if [ ${OS_VERSION} -lt 8 ]; then
   sudo yum install -y yum-utils
   DNF_DOWNLOAD="yumdownloader"
   DNF_REPOQUERY_DEPLIST="yum deplist"
+elif [ ${OS_VERSION} -eq 8 ]; then
+  sudo dnf install -y 'dnf-command(download)'
+  DNF_DOWNLOAD="dnf download -y"
+  DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist --enable-repo powertools"
 else
   sudo dnf install -y 'dnf-command(download)'
   DNF_DOWNLOAD="dnf download -y"

--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -22,8 +22,9 @@ if [ ${OS_VERSION} -lt 8 ]; then
   DNF_REPOQUERY_DEPLIST="yum deplist"
 elif [ ${OS_VERSION} -eq 8 ]; then
   sudo dnf install -y 'dnf-command(download)'
+  sudo dnf config-manager --set-enabled powertools || :
   DNF_DOWNLOAD="dnf download -y"
-  DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist --enable-repo powertools"
+  DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist"
 else
   sudo dnf install -y 'dnf-command(download)'
   DNF_DOWNLOAD="dnf download -y"

--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -20,10 +20,6 @@ if [ ${OS_VERSION} -lt 8 ]; then
   sudo yum install -y yum-utils
   DNF_DOWNLOAD="yumdownloader"
   DNF_REPOQUERY_DEPLIST="yum deplist"
-elif [ ${OS_VERSION} -eq 8 ]; then
-  sudo dnf install -y 'dnf-command(download)'
-  DNF_DOWNLOAD="dnf download -y"
-  DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist --enable-repo powertools"
 else
   sudo dnf install -y 'dnf-command(download)'
   DNF_DOWNLOAD="dnf download -y"

--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -22,9 +22,8 @@ if [ ${OS_VERSION} -lt 8 ]; then
   DNF_REPOQUERY_DEPLIST="yum deplist"
 elif [ ${OS_VERSION} -eq 8 ]; then
   sudo dnf install -y 'dnf-command(download)'
-  sudo dnf config-manager --set-enabled powertools || :
   DNF_DOWNLOAD="dnf download -y"
-  DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist"
+  DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist --enable-repo powertools"
 else
   sudo dnf install -y 'dnf-command(download)'
   DNF_DOWNLOAD="dnf download -y"

--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -21,6 +21,9 @@ if [ ${OS_VERSION} -lt 8 ]; then
   DNF_DOWNLOAD="yumdownloader"
   DNF_REPOQUERY_DEPLIST="yum deplist"
 else
+  if [ ${OS_VERSION} -eq 8 ]; then
+    sudo dnf config-manager --set-enabled powertools || :
+  fi
   sudo dnf install -y 'dnf-command(download)'
   DNF_DOWNLOAD="dnf download -y"
   DNF_REPOQUERY_DEPLIST="dnf repoquery --deplist"


### PR DESCRIPTION
Because gflags and glog are not downloaded when we use this tool in AlmaLinux 8.