### PR TITLE
tools/download-rpm: add download targets

### DIFF
--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -115,3 +115,13 @@ if [ ${USE_MECAB:-no} = "yes" ]; then
   download_recursive \
     groonga-tokenizer-mecab-${GROONGA_VERSION}-1.el${OS_VERSION}
 fi
+
+if [ ${USE_PLUGIN_SUGGEST:-no} = "yes" ]; then
+  download_recursive \
+    groonga-plugin-suggest-${GROONGA_VERSION}-1.el${OS_VERSION}
+fi
+
+if [ ${USE_GROONGA_BIN:-no} = "yes" ]; then
+  download_recursive \
+    groonga-${GROONGA_VERSION}-1.el${OS_VERSION}
+fi

--- a/tools/download-rpm.sh
+++ b/tools/download-rpm.sh
@@ -116,7 +116,7 @@ if [ ${USE_MECAB:-no} = "yes" ]; then
     groonga-tokenizer-mecab-${GROONGA_VERSION}-1.el${OS_VERSION}
 fi
 
-if [ ${USE_PLUGIN_SUGGEST:-no} = "yes" ]; then
+if [ ${USE_GROONGA_PLUGIN_SUGGEST:-no} = "yes" ]; then
   download_recursive \
     groonga-plugin-suggest-${GROONGA_VERSION}-1.el${OS_VERSION}
 fi


### PR DESCRIPTION
We can download RPM for groonga-plugin-suggest and groonga if we use "USE_GROONGA_PLUGIN_SUGGEST=yes" and "USE_GROONGA_BIN=yes" as below.

```bash
USE_GROONGA_PLUGIN_SUGGEST=yes \
USE_GROONGA_BIN=yes \
  /pgroonga/tools/download-rpm.sh \
    ${PGROONGA_VERSION} \
    ${GROONGA_VERSION} \
    ${POSTGRESQL_VERSION}
```