### PR TITLE
ci windows: use the latest versions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,18 +25,18 @@ jobs:
       matrix:
         include:
           - postgresql-version-major: "12"
-            postgresql-version: "12.15-1"
+            postgresql-version: "12.18-1"
           - postgresql-version-major: "13"
-            postgresql-version: "13.11-1"
+            postgresql-version: "13.14-1"
           - postgresql-version-major: "14"
-            postgresql-version: "14.8-1"
+            postgresql-version: "14.11-1"
           - postgresql-version-major: "15"
-            postgresql-version: "15.3-1"
+            postgresql-version: "15.6-1"
           - postgresql-version-major: "16"
-            postgresql-version: "16.0-1"
+            postgresql-version: "16.2-1"
           - groonga-main: "yes"
             postgresql-version-major: "16"
-            postgresql-version: "16.0-1"
+            postgresql-version: "16.2-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"


### PR DESCRIPTION
Because PostgreSQL 16.2, 15.6, 14.11, 13.14, and 12.18 released at 2024-02-08.