### PR TITLE
Fix a crash on connection close

### DIFF
--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -409,6 +409,9 @@ PGrnBeforeShmemExit(int code, Datum arg)
 {
 	const char *tag = "pgroonga: [exit]";
 
+	UnregisterResourceReleaseCallback(PGrnReleaseScanOpaques, NULL);
+	UnregisterResourceReleaseCallback(PGrnReleaseSequentialSearch, NULL);
+
 	if (ctx)
 	{
 		grn_obj *db;


### PR DESCRIPTION
This is happen when the following conditions are satisfied:

* In transaction
* `(nExecutions % vacuumFrequency) == 0`
  * https://github.com/pgroonga/pgroonga/blob/c9804ab4801ff0e77cf38775063a933425cb2150/src/pgrn-sequential-search.c#L157

In this case, `PGrnBeforeShmemExit()` is executed before `PGrnReleaseSequentialSearch()`. And `PGrnReleaseSequentialSearch()` touches a Groonga object. But `grn_fin()` is called in `PGrnBeforeShmemExit()`. So touching a Groonga object crashes the process.

We don't need to run `PGrnReleaseSequentialSearch()` because all resources are released in `PGrnBeforeShmemExit()`. So we can unregister all resource release callbacks.
