### PR TITLE
list-broken-indexes: Returns a list of PGroonga indexes

### DIFF
--- a/data/pgroonga--3.2.0--3.2.1.sql
+++ b/data/pgroonga--3.2.0--3.2.1.sql
@@ -1,7 +1,7 @@
 -- Upgrade SQL
 
 CREATE FUNCTION pgroonga_list_broken_indexes()
-	RETURNS void /* todo */
+	RETURNS SETOF text
 	AS 'MODULE_PATHNAME', 'pgroonga_list_broken_indexes'
 	LANGUAGE C
 	STRICT

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -435,7 +435,7 @@ CREATE FUNCTION pgroonga_wal_set_applied_position()
 	STRICT;
 
 CREATE FUNCTION pgroonga_list_broken_indexes()
-	RETURNS void /* todo */
+	RETURNS SETOF text
 	AS 'MODULE_PATHNAME', 'pgroonga_list_broken_indexes'
 	LANGUAGE C
 	STRICT

--- a/expected/function/list-broken-indexes/multiple.out
+++ b/expected/function/list-broken-indexes/multiple.out
@@ -1,0 +1,17 @@
+CREATE TABLE memos (
+  content text
+);
+CREATE TABLE tags (
+  name text
+);
+CREATE INDEX pgrn_memos_index ON memos USING PGroonga (content);
+CREATE INDEX pgrn_tags_index ON tags USING PGroonga (name);
+SELECT * FROM pgroonga_list_broken_indexes();
+ pgroonga_list_broken_indexes 
+------------------------------
+ pgrn_memos_index
+ pgrn_tags_index
+(2 rows)
+
+DROP TABLE memos;
+DROP TABLE tags;

--- a/expected/function/list-broken-indexes/nothing.out
+++ b/expected/function/list-broken-indexes/nothing.out
@@ -1,6 +1,5 @@
 SELECT * FROM pgroonga_list_broken_indexes();
  pgroonga_list_broken_indexes 
 ------------------------------
- 
-(1 row)
+(0 rows)
 

--- a/sql/function/list-broken-indexes/multiple.sql
+++ b/sql/function/list-broken-indexes/multiple.sql
@@ -1,0 +1,15 @@
+CREATE TABLE memos (
+  content text
+);
+
+CREATE TABLE tags (
+  name text
+);
+
+CREATE INDEX pgrn_memos_index ON memos USING PGroonga (content);
+CREATE INDEX pgrn_tags_index ON tags USING PGroonga (name);
+
+SELECT * FROM pgroonga_list_broken_indexes();
+
+DROP TABLE memos;
+DROP TABLE tags;

--- a/src/pgrn-list-broken-indexes.c
+++ b/src/pgrn-list-broken-indexes.c
@@ -1,18 +1,76 @@
 #include "pgroonga.h"
 
+#include "pgrn-compatible.h"
+
+#include <access/heapam.h>
 #include <funcapi.h>
+#include <miscadmin.h>
+#include <utils/acl.h>
+#include <utils/builtins.h>
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_list_broken_indexes);
+
+typedef struct
+{
+	Relation indexes;
+	TableScanDesc scan;
+} PGrnListBrokenIndexData;
 
 Datum
 pgroonga_list_broken_indexes(PG_FUNCTION_ARGS)
 {
 	FuncCallContext *context;
+	LOCKMODE lock = AccessShareLock;
+	PGrnListBrokenIndexData *data;
+	HeapTuple indexTuple;
+
 	if (SRF_IS_FIRSTCALL())
 	{
+		MemoryContext oldContext;
 		context = SRF_FIRSTCALL_INIT();
+		oldContext = MemoryContextSwitchTo(context->multi_call_memory_ctx);
+
+		data = palloc(sizeof(PGrnListBrokenIndexData));
+		data->indexes = table_open(IndexRelationId, lock);
+		data->scan = table_beginscan_catalog(data->indexes, 0, NULL);
+		context->user_fctx = data;
+
+		MemoryContextSwitchTo(oldContext);
 	}
+
 	context = SRF_PERCALL_SETUP();
+	data = context->user_fctx;
+
+	while ((indexTuple = heap_getnext(data->scan, ForwardScanDirection)))
+	{
+		Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(indexTuple);
+		Relation index;
+		Datum name;
+
+		if (!pgrn_pg_class_ownercheck(indexForm->indexrelid, GetUserId()))
+			continue;
+
+		index = RelationIdGetRelation(indexForm->indexrelid);
+		if (!PGrnIndexIsPGroonga(index))
+		{
+			RelationClose(index);
+			continue;
+		}
+		if (PGRN_RELKIND_HAS_PARTITIONS(index->rd_rel->relkind))
+		{
+			RelationClose(index);
+			continue;
+		}
+
+		name = PointerGetDatum(cstring_to_text(RelationGetRelationName(index)));
+		RelationClose(index);
+		SRF_RETURN_NEXT(context, name);
+	}
+
 	// todo
+	// Filtering broken indexes
+
+	heap_endscan(data->scan);
+	table_close(data->indexes, lock);
 	SRF_RETURN_DONE(context);
 }


### PR DESCRIPTION
Prepare to implement a function that lists the indexes of PGroonga's that may be broken. After this, add a process to filter only broken indexes.