### PR TITLE
ci: Run macos test with `macos-12`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
           - "16"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}/pgroonga-benchmark/Gemfile
-    runs-on: macos-latest
+    runs-on: macos-12 # TODO: It fails with macos-latest (macos-14).
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Because `macos-latest` (Image: macos-14-arm64) fails.