### PR TITLE
Add pgroonga_list_lagged_indexes() skeleton

### DIFF
--- a/data/pgroonga--3.2.0--3.2.1.sql
+++ b/data/pgroonga--3.2.0--3.2.1.sql
@@ -1,5 +1,12 @@
 -- Upgrade SQL
 
+CREATE FUNCTION pgroonga_list_lagged_indexes()
+	RETURNS void /* todo */
+	AS 'MODULE_PATHNAME', 'pgroonga_list_lagged_indexes'
+	LANGUAGE C
+	STRICT
+	PARALLEL SAFE;
+
 CREATE FUNCTION pgroonga_list_broken_indexes()
 	RETURNS SETOF text
 	AS 'MODULE_PATHNAME', 'pgroonga_list_broken_indexes'

--- a/data/pgroonga--3.2.1--3.2.0.sql
+++ b/data/pgroonga--3.2.1--3.2.0.sql
@@ -1,3 +1,4 @@
 -- Downgrade SQL
 
+DROP FUNCTION pgroonga_list_lagged_indexes;
 DROP FUNCTION pgroonga_list_broken_indexes;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -434,6 +434,13 @@ CREATE FUNCTION pgroonga_wal_set_applied_position()
 	LANGUAGE C
 	STRICT;
 
+CREATE FUNCTION pgroonga_list_lagged_indexes()
+	RETURNS void /* todo */
+	AS 'MODULE_PATHNAME', 'pgroonga_list_lagged_indexes'
+	LANGUAGE C
+	STRICT
+	PARALLEL SAFE;
+
 CREATE FUNCTION pgroonga_list_broken_indexes()
 	RETURNS SETOF text
 	AS 'MODULE_PATHNAME', 'pgroonga_list_broken_indexes'

--- a/src/pgrn-wal.c
+++ b/src/pgrn-wal.c
@@ -97,6 +97,7 @@ PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_wal_set_applied_position_index);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_wal_set_applied_position_index_last);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_wal_set_applied_position_all);
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_wal_set_applied_position_all_last);
+PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_list_lagged_indexes);
 
 #if defined(PGRN_SUPPORT_WAL) || defined(PGRN_SUPPORT_WAL_RESOURCE_MANAGER)
 static struct PGrnBuffers *buffers = &PGrnBuffers;
@@ -3655,4 +3656,20 @@ pgroonga_wal_set_applied_position_all_last(PG_FUNCTION_ARGS)
 	PGrnCheckRC(GRN_FUNCTION_NOT_IMPLEMENTED, "%s not supported", tag);
 #endif
 	PG_RETURN_BOOL(true);
+}
+
+/**
+ * pgroonga_list_lagged_indexes() : SETOF text
+ */
+Datum
+pgroonga_list_lagged_indexes(PG_FUNCTION_ARGS)
+{
+	FuncCallContext *context;
+	if (SRF_IS_FIRSTCALL())
+	{
+		context = SRF_FIRSTCALL_INIT();
+	}
+	context = SRF_PERCALL_SETUP();
+	// todo
+	SRF_RETURN_DONE(context);
 }

--- a/test/test-streaming-replication.rb
+++ b/test/test-streaming-replication.rb
@@ -724,4 +724,23 @@ CREATE TABLE cities_20_01 PARTITION OF cities FOR VALUES IN ('20-01');
       end
     end
   end
+
+  sub_test_case "pgroonga_list_lagged_indexes" do
+    test "lagging" do
+      run_sql("CREATE TABLE memos (content text);")
+      run_sql("CREATE INDEX memos_content ON memos USING pgroonga (content);")
+      run_sql("INSERT INTO memos VALUES ('PGroonga is good!');")
+
+      output = <<-OUTPUT
+SELECT * FROM pgroonga_list_lagged_indexes()
+ pgroonga_list_lagged_indexes 
+------------------------------
+ 
+(1 row)
+
+      OUTPUT
+      assert_equal([output, ""],
+                   run_sql_standby("SELECT * FROM pgroonga_list_lagged_indexes()"))
+    end
+  end
 end


### PR DESCRIPTION
Prepare to implement a function that returns a list of PGroonga indexes with unapplied WAL.