### PR TITLE
Check with PGrnCheck() after `grn_expr_append_op` in pgroonga.c

### DIFF
--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -1437,7 +1437,7 @@ PGrnCollectScoreMultiColumnPrimaryKey(Relation table,
 									  HeapTuple tuple,
 									  PGrnScanOpaque so)
 {
-	const char *tag = "pgroonga: [score][multi-column-primary-key][collect]";
+	const char *tag = "[score][multi-column-primary-key][collect]";
 	double score = 0.0;
 	TupleDesc desc;
 	grn_obj *expression;

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -3484,8 +3484,8 @@ pgroonga_prefix_rk_raw(const char *text,
 							  1);
 	grn_expr_append_op(ctx, expression, GRN_OP_CALL, 2);
 	PGrnCheck("%s: failed to append operator: %s",
-			tag,
-			grn_operator_to_string(GRN_OP_CALL));
+			  tag,
+			  grn_operator_to_string(GRN_OP_CALL));
 
 	id = grn_table_add(
 		ctx, prefixRKSequentialSearchData.table, text, textSize, NULL);
@@ -5569,8 +5569,8 @@ PGrnSearchBuildConditionLikeMatchFlush(grn_obj *expression,
 	grn_expr_append_obj(ctx, expression, targetColumn, GRN_OP_PUSH, 1);
 	grn_expr_append_op(ctx, expression, GRN_OP_GET_VALUE, 1);
 	PGrnCheck("%s: failed to append operator: %s",
-			tag,
-			grn_operator_to_string(GRN_OP_GET_VALUE));
+			  tag,
+			  grn_operator_to_string(GRN_OP_GET_VALUE));
 
 	grn_expr_append_const_str(ctx,
 							  expression,
@@ -5580,14 +5580,14 @@ PGrnSearchBuildConditionLikeMatchFlush(grn_obj *expression,
 							  1);
 	grn_expr_append_op(ctx, expression, GRN_OP_MATCH, 2);
 	PGrnCheck("%s: failed to append operator: %s",
-			tag,
-			grn_operator_to_string(GRN_OP_MATCH));
+			  tag,
+			  grn_operator_to_string(GRN_OP_MATCH));
 	if (*nKeywords > 0)
 	{
 		grn_expr_append_op(ctx, expression, GRN_OP_OR, 2);
 		PGrnCheck("%s: failed to append operator: %s",
-				tag,
-				grn_operator_to_string(GRN_OP_MATCH));
+				  tag,
+				  grn_operator_to_string(GRN_OP_MATCH));
 	}
 	(*nKeywords)++;
 
@@ -5653,8 +5653,8 @@ PGrnSearchBuildConditionLikeMatch(PGrnSearchData *data,
 							1);
 		grn_expr_append_op(ctx, expression, GRN_OP_CALL, 0);
 		PGrnCheck("%s: failed to append operator: %s",
-				tag,
-				grn_operator_to_string(GRN_OP_CALL));
+				  tag,
+				  grn_operator_to_string(GRN_OP_CALL));
 	}
 }
 

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -1437,6 +1437,7 @@ PGrnCollectScoreMultiColumnPrimaryKey(Relation table,
 									  HeapTuple tuple,
 									  PGrnScanOpaque so)
 {
+	const char *tag = "pgroonga: [score][multi-column-primary-key][collect]";
 	double score = 0.0;
 	TupleDesc desc;
 	grn_obj *expression;
@@ -1482,12 +1483,23 @@ PGrnCollectScoreMultiColumnPrimaryKey(Relation table,
 		grn_expr_append_obj(
 			ctx, expression, primaryKeyColumn->column, GRN_OP_PUSH, 1);
 		grn_expr_append_op(ctx, expression, GRN_OP_GET_VALUE, 1);
+		PGrnCheck("%s: failed to append operator: %s",
+				  tag,
+				  grn_operator_to_string(GRN_OP_GET_VALUE));
 		grn_expr_append_const(
 			ctx, expression, &(buffers->general), GRN_OP_PUSH, 1);
 		grn_expr_append_op(ctx, expression, GRN_OP_EQUAL, 2);
+		PGrnCheck("%s: failed to append operator: %s",
+				  tag,
+				  grn_operator_to_string(GRN_OP_EQUAL));
 
 		if (nPrimaryKeyColumns > 0)
+		{
 			grn_expr_append_op(ctx, expression, GRN_OP_AND, 2);
+			PGrnCheck("%s: failed to append operator: %s",
+					  tag,
+					  grn_operator_to_string(GRN_OP_AND));
+		}
 		nPrimaryKeyColumns++;
 	}
 	grn_table_select(
@@ -3471,6 +3483,9 @@ pgroonga_prefix_rk_raw(const char *text,
 							  GRN_OP_PUSH,
 							  1);
 	grn_expr_append_op(ctx, expression, GRN_OP_CALL, 2);
+	PGrnCheck("%s: failed to append operator: %s",
+			tag,
+			grn_operator_to_string(GRN_OP_CALL));
 
 	id = grn_table_add(
 		ctx, prefixRKSequentialSearchData.table, text, textSize, NULL);
@@ -5547,11 +5562,16 @@ PGrnSearchBuildConditionLikeMatchFlush(grn_obj *expression,
 									   grn_obj *keyword,
 									   int *nKeywords)
 {
+	const char *tag = "[build-condition][like-match-flush]";
 	if (GRN_TEXT_LEN(keyword) == 0)
 		return;
 
 	grn_expr_append_obj(ctx, expression, targetColumn, GRN_OP_PUSH, 1);
 	grn_expr_append_op(ctx, expression, GRN_OP_GET_VALUE, 1);
+	PGrnCheck("%s: failed to append operator: %s",
+			tag,
+			grn_operator_to_string(GRN_OP_GET_VALUE));
+
 	grn_expr_append_const_str(ctx,
 							  expression,
 							  GRN_TEXT_VALUE(keyword),
@@ -5559,8 +5579,16 @@ PGrnSearchBuildConditionLikeMatchFlush(grn_obj *expression,
 							  GRN_OP_PUSH,
 							  1);
 	grn_expr_append_op(ctx, expression, GRN_OP_MATCH, 2);
+	PGrnCheck("%s: failed to append operator: %s",
+			tag,
+			grn_operator_to_string(GRN_OP_MATCH));
 	if (*nKeywords > 0)
+	{
 		grn_expr_append_op(ctx, expression, GRN_OP_OR, 2);
+		PGrnCheck("%s: failed to append operator: %s",
+				tag,
+				grn_operator_to_string(GRN_OP_MATCH));
+	}
 	(*nKeywords)++;
 
 	GRN_BULK_REWIND(keyword);
@@ -5571,6 +5599,7 @@ PGrnSearchBuildConditionLikeMatch(PGrnSearchData *data,
 								  grn_obj *targetColumn,
 								  grn_obj *query)
 {
+	const char *tag = "[build-condition][like-match]";
 	grn_obj *expression;
 	const char *queryRaw;
 	size_t i, querySize;
@@ -5623,6 +5652,9 @@ PGrnSearchBuildConditionLikeMatch(PGrnSearchData *data,
 							GRN_OP_PUSH,
 							1);
 		grn_expr_append_op(ctx, expression, GRN_OP_CALL, 0);
+		PGrnCheck("%s: failed to append operator: %s",
+				tag,
+				grn_operator_to_string(GRN_OP_CALL));
 	}
 }
 

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5587,7 +5587,7 @@ PGrnSearchBuildConditionLikeMatchFlush(grn_obj *expression,
 		grn_expr_append_op(ctx, expression, GRN_OP_OR, 2);
 		PGrnCheck("%s: failed to append operator: %s",
 				  tag,
-				  grn_operator_to_string(GRN_OP_MATCH));
+				  grn_operator_to_string(GRN_OP_OR));
 	}
 	(*nKeywords)++;
 


### PR DESCRIPTION
If it failed, PGroonga crashes, so it is checked by PGrnCheck().

This commit does not add checks to all `grn_expr_append_op`.
It is split up because of the many targets.