### PR TITLE
Add `fuzzy_max_distance_ratio` parameter to pgroonga_condition()

### DIFF
--- a/data/pgroonga--3.2.0--3.2.1.sql
+++ b/data/pgroonga--3.2.0--3.2.1.sql
@@ -1,5 +1,30 @@
 -- Upgrade SQL
 
+ALTER TYPE pgroonga_condition ADD ATTRIBUTE fuzzy_max_distance_ratio float4;
+CREATE OR REPLACE FUNCTION pgroonga_condition(query text = null,
+				   weights int[] = null,
+				   scorers text[] = null,
+				   schema_name text = null,
+				   index_name text = null,
+				   column_name text = null,
+				   fuzzy_max_distance_ratio float4 = null)
+	RETURNS pgroonga_condition
+	LANGUAGE SQL
+	AS $$
+		SELECT (
+			query,
+			weights,
+			scorers,
+			schema_name,
+			index_name,
+			column_name,
+			fuzzy_max_distance_ratio
+		)::pgroonga_condition
+	$$
+	IMMUTABLE
+	LEAKPROOF
+	PARALLEL SAFE;
+
 DO LANGUAGE plpgsql $$
 DECLARE
 	rec record;

--- a/data/pgroonga--3.2.1--3.2.0.sql
+++ b/data/pgroonga--3.2.1--3.2.0.sql
@@ -1,4 +1,27 @@
 -- Downgrade SQL
 
+ALTER TYPE pgroonga_condition DROP ATTRIBUTE fuzzy_max_distance_ratio;
+CREATE OR REPLACE FUNCTION pgroonga_condition(query text = null,
+				   weights int[] = null,
+				   scorers text[] = null,
+				   schema_name text = null,
+				   index_name text = null,
+				   column_name text = null)
+	RETURNS pgroonga_condition
+	LANGUAGE SQL
+	AS $$
+		SELECT (
+			query,
+			weights,
+			scorers,
+			schema_name,
+			index_name,
+			column_name
+		)::pgroonga_condition
+	$$
+	IMMUTABLE
+	LEAKPROOF
+	PARALLEL SAFE;
+
 DROP FUNCTION pgroonga_list_lagged_indexes;
 DROP FUNCTION pgroonga_list_broken_indexes;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -19,7 +19,8 @@ CREATE TYPE pgroonga_condition AS (
 	scorers text[],
 	schema_name text,
 	index_name text,
-	column_name text
+	column_name text,
+	fuzzy_max_distance_ratio float4
 );
 
 CREATE FUNCTION pgroonga_condition(query text = null,
@@ -27,7 +28,8 @@ CREATE FUNCTION pgroonga_condition(query text = null,
 				   scorers text[] = null,
 				   schema_name text = null,
 				   index_name text = null,
-				   column_name text = null)
+				   column_name text = null,
+				   fuzzy_max_distance_ratio float4 = null)
 	RETURNS pgroonga_condition
 	LANGUAGE SQL
 	AS $$
@@ -37,7 +39,8 @@ CREATE FUNCTION pgroonga_condition(query text = null,
 			scorers,
 			schema_name,
 			index_name,
-			column_name
+			column_name,
+			fuzzy_max_distance_ratio
 		)::pgroonga_condition
 	$$
 	IMMUTABLE

--- a/expected/term-search/text/equal-condition/row-level-security/bitmapscan.out
+++ b/expected/term-search/text/equal-condition/row-level-security/bitmapscan.out
@@ -28,10 +28,10 @@ QUERY PLAN
 Sort
   Sort Key: id
   ->  Bitmap Heap Scan on tags
-        Recheck Cond: (name &= '(groonga,,,,pgrn_index,)'::pgroonga_condition)
+        Recheck Cond: (name &= '(groonga,,,,pgrn_index,,)'::pgroonga_condition)
         Filter: (user_name = CURRENT_USER)
         ->  Bitmap Index Scan on pgrn_index
-              Index Cond: (name &= '(groonga,,,,pgrn_index,)'::pgroonga_condition)
+              Index Cond: (name &= '(groonga,,,,pgrn_index,,)'::pgroonga_condition)
 (7 rows)
 \pset format aligned
 SELECT name

--- a/expected/term-search/text/equal-condition/row-level-security/indexscan.out
+++ b/expected/term-search/text/equal-condition/row-level-security/indexscan.out
@@ -28,7 +28,7 @@ QUERY PLAN
 Sort
   Sort Key: id
   ->  Index Scan using pgrn_index on tags
-        Index Cond: (name &= '(groonga,,,,pgrn_index,)'::pgroonga_condition)
+        Index Cond: (name &= '(groonga,,,,pgrn_index,,)'::pgroonga_condition)
         Filter: (user_name = CURRENT_USER)
 (5 rows)
 \pset format aligned

--- a/expected/term-search/text/equal-condition/row-level-security/seqscan.out
+++ b/expected/term-search/text/equal-condition/row-level-security/seqscan.out
@@ -28,7 +28,7 @@ QUERY PLAN
 Sort
   Sort Key: id
   ->  Seq Scan on tags
-        Filter: ((user_name = CURRENT_USER) AND (name &= '(groonga,,,,pgrn_index,)'::pgroonga_condition))
+        Filter: ((user_name = CURRENT_USER) AND (name &= '(groonga,,,,pgrn_index,,)'::pgroonga_condition))
 (4 rows)
 \pset format aligned
 SELECT name

--- a/src/pgrn-condition.c
+++ b/src/pgrn-condition.c
@@ -103,7 +103,7 @@ PGrnConditionDeconstruct(PGrnCondition *condition, HeapTupleHeader header)
 			}
 			else if (i == fuzzyMaxDistanceRatioIndex)
 			{
-				condition->fuzzyMaxDistanceRatio = -1.0;
+				condition->fuzzyMaxDistanceRatio = 0.0;
 			}
 			continue;
 		}

--- a/src/pgrn-condition.c
+++ b/src/pgrn-condition.c
@@ -25,6 +25,7 @@ PGrnConditionDeconstruct(PGrnCondition *condition, HeapTupleHeader header)
 	int schemaNameIndex = -1;
 	int indexNameIndex = -1;
 	int columnNameIndex = -1;
+	int fuzzyMaxDistanceRatioIndex = -1;
 
 	type = HeapTupleHeaderGetTypeId(header);
 	typmod = HeapTupleHeaderGetTypMod(header);
@@ -63,6 +64,7 @@ PGrnConditionDeconstruct(PGrnCondition *condition, HeapTupleHeader header)
 		schemaNameIndex = 3;
 		indexNameIndex = 4;
 		columnNameIndex = 5;
+		fuzzyMaxDistanceRatioIndex = 6;
 	}
 
 	for (i = 0; i < desc->natts; i++)
@@ -99,6 +101,10 @@ PGrnConditionDeconstruct(PGrnCondition *condition, HeapTupleHeader header)
 			{
 				condition->columnName = NULL;
 			}
+			else if (i == fuzzyMaxDistanceRatioIndex)
+			{
+				condition->fuzzyMaxDistanceRatio = -1.0;
+			}
 			continue;
 		}
 
@@ -129,6 +135,10 @@ PGrnConditionDeconstruct(PGrnCondition *condition, HeapTupleHeader header)
 		else if (i == columnNameIndex)
 		{
 			condition->columnName = DatumGetTextPP(datum);
+		}
+		else if (i == fuzzyMaxDistanceRatioIndex)
+		{
+			condition->fuzzyMaxDistanceRatio = DatumGetFloat4(datum);
 		}
 
 		offset =

--- a/src/pgrn-condition.h
+++ b/src/pgrn-condition.h
@@ -15,6 +15,7 @@ typedef struct
 	text *schemaName;
 	text *indexName;
 	text *columnName;
+	float4 fuzzyMaxDistanceRatio;
 	grn_obj *isTargets;
 } PGrnCondition;
 


### PR DESCRIPTION
Make Groonga's `fuzzy_max_distance_ratio` can be used in pgroonga_condition().
https://groonga.org/docs/reference/commands/select.html#typo-tolerance

This commit just implements the passing of `fuzzy_max_distance_ratio`.
Implementation of search using `fuzzy_max_distance_ratio` will be a separate commit.