### PR TITLE
pgroonga-primary-maintainer:  Register a background worker

### DIFF
--- a/src/pgroonga-primary-maintainer.c
+++ b/src/pgroonga-primary-maintainer.c
@@ -1,15 +1,51 @@
 #include "pgrn-compatible.h"
 
 #include <fmgr.h>
+#include <miscadmin.h>
+#include <postmaster/bgworker.h>
+#include <storage/ipc.h>
 
 PG_MODULE_MAGIC;
 
+extern PGDLLEXPORT void _PG_init(void);
+extern PGDLLEXPORT void pgroonga_primary_maintainer_main(Datum datum)
+	pg_attribute_noreturn();
+
 #define TAG "pgroonga: primary-maintainer"
 
-extern PGDLLEXPORT void _PG_init(void);
+static const char *PGroongaPrimaryMaintainerLibraryName =
+	"pgroonga_primary_maintainer";
+
+void
+pgroonga_primary_maintainer_main(Datum arg)
+{
+	elog(LOG, TAG ": debug");
+	proc_exit(1);
+}
 
 void
 _PG_init(void)
 {
-	elog(LOG, TAG ": debug");
+	BackgroundWorker worker = {0};
+
+	if (!process_shared_preload_libraries_in_progress)
+		return;
+
+	snprintf(worker.bgw_name, BGW_MAXLEN, TAG ": main");
+	snprintf(worker.bgw_type, BGW_MAXLEN, "%s", worker.bgw_name);
+	worker.bgw_flags =
+		BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+	worker.bgw_restart_time = BGW_NEVER_RESTART;
+	snprintf(worker.bgw_library_name,
+			 BGW_MAXLEN,
+			 "%s",
+			 PGroongaPrimaryMaintainerLibraryName);
+	snprintf(worker.bgw_function_name,
+			 BGW_MAXLEN,
+			 "pgroonga_primary_maintainer_main");
+	worker.bgw_main_arg = 0;
+	worker.bgw_notify_pid = 0;
+
+	RegisterBackgroundWorker(&worker);
 }

--- a/test/test-streaming-replication.rb
+++ b/test/test-streaming-replication.rb
@@ -434,6 +434,16 @@ SELECT title FROM memos WHERE content &@~ '0'
     end
   end
 
+  sub_test_case "pgroonga_primary_maintainer" do
+    def shared_preload_libraries
+      ["pgroonga_primary_maintainer"]
+    end
+
+    test "(temporary)" do
+      assert @postgresql.read_log.include?("pgroonga: primary-maintainer: debug")
+    end
+  end
+
   sub_test_case "pgroonga_standby_maintainer" do
     def shared_preload_libraries_standby
       ["pgroonga_standby_maintainer"]


### PR DESCRIPTION
After this, the following features will be implemented.

* Check WAL size
* Run `REINDEX CONCURRENTLY`
* Routine run in pgroonga_primary_maintainer_main