### PR TITLE
query-v2: Fix a crash bug with multiple conditions including blank only query condition

### DIFF
--- a/expected/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.out
+++ b/expected/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.out
@@ -12,8 +12,8 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = on;
 SELECT id, content
   FROM memos
- WHERE content &@~ pgroonga_condition('PGroonga')
- AND content &@~ pgroonga_condition(' ');
+ WHERE content &@~ pgroonga_condition('PGroonga') AND
+       content &@~ pgroonga_condition(' ');
  id | content 
 ----+---------
 (0 rows)

--- a/expected/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.out
+++ b/expected/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.out
@@ -1,0 +1,21 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_full_text_search_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+SELECT id, content
+  FROM memos
+ WHERE content &@~ pgroonga_condition('PGroonga')
+ AND content &@~ pgroonga_condition(' ');
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/full-text-search/text/single/query-condition-v2/and/blank/indexscan.out
+++ b/expected/full-text-search/text/single/query-condition-v2/and/blank/indexscan.out
@@ -12,8 +12,8 @@ SET enable_indexscan = on;
 SET enable_bitmapscan = off;
 SELECT id, content
   FROM memos
- WHERE content &@~ pgroonga_condition('PGroonga')
- AND content &@~ pgroonga_condition(' ');
+ WHERE content &@~ pgroonga_condition('PGroonga') AND
+       content &@~ pgroonga_condition(' ');
  id | content 
 ----+---------
 (0 rows)

--- a/expected/full-text-search/text/single/query-condition-v2/and/blank/indexscan.out
+++ b/expected/full-text-search/text/single/query-condition-v2/and/blank/indexscan.out
@@ -1,0 +1,21 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_full_text_search_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+SELECT id, content
+  FROM memos
+ WHERE content &@~ pgroonga_condition('PGroonga')
+ AND content &@~ pgroonga_condition(' ');
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/full-text-search/text/single/query-condition-v2/and/blank/seqscan.out
+++ b/expected/full-text-search/text/single/query-condition-v2/and/blank/seqscan.out
@@ -12,8 +12,8 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT id, content
   FROM memos
- WHERE content &@~ pgroonga_condition('PGroonga')
- AND content &@~ pgroonga_condition(' ');
+ WHERE content &@~ pgroonga_condition('PGroonga') AND
+       content &@~ pgroonga_condition(' ');
  id | content 
 ----+---------
 (0 rows)

--- a/expected/full-text-search/text/single/query-condition-v2/and/blank/seqscan.out
+++ b/expected/full-text-search/text/single/query-condition-v2/and/blank/seqscan.out
@@ -1,0 +1,21 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_full_text_search_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT id, content
+  FROM memos
+ WHERE content &@~ pgroonga_condition('PGroonga')
+ AND content &@~ pgroonga_condition(' ');
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/full-text-search/text/single/query-v2/and/blank/bitmapscan.out
+++ b/expected/full-text-search/text/single/query-v2/and/blank/bitmapscan.out
@@ -1,0 +1,19 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX grnindex ON memos USING pgroonga (content);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga' AND content &@~ ' ';
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/full-text-search/text/single/query-v2/and/blank/indexscan.out
+++ b/expected/full-text-search/text/single/query-v2/and/blank/indexscan.out
@@ -1,0 +1,19 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX grnindex ON memos USING pgroonga (content);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga' AND content &@~ ' ';
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/full-text-search/text/single/query-v2/and/blank/seqscan.out
+++ b/expected/full-text-search/text/single/query-v2/and/blank/seqscan.out
@@ -1,0 +1,19 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX grnindex ON memos USING pgroonga (content);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga' AND content &@~ ' ';
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.sql
+++ b/sql/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.sql
@@ -1,0 +1,22 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_full_text_search_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ pgroonga_condition('PGroonga')
+ AND content &@~ pgroonga_condition(' ');
+
+DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.sql
+++ b/sql/full-text-search/text/single/query-condition-v2/and/blank/bitmapscan.sql
@@ -16,7 +16,7 @@ SET enable_bitmapscan = on;
 
 SELECT id, content
   FROM memos
- WHERE content &@~ pgroonga_condition('PGroonga')
- AND content &@~ pgroonga_condition(' ');
+ WHERE content &@~ pgroonga_condition('PGroonga') AND
+       content &@~ pgroonga_condition(' ');
 
 DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-condition-v2/and/blank/indexscan.sql
+++ b/sql/full-text-search/text/single/query-condition-v2/and/blank/indexscan.sql
@@ -16,7 +16,7 @@ SET enable_bitmapscan = off;
 
 SELECT id, content
   FROM memos
- WHERE content &@~ pgroonga_condition('PGroonga')
- AND content &@~ pgroonga_condition(' ');
+ WHERE content &@~ pgroonga_condition('PGroonga') AND
+       content &@~ pgroonga_condition(' ');
 
 DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-condition-v2/and/blank/indexscan.sql
+++ b/sql/full-text-search/text/single/query-condition-v2/and/blank/indexscan.sql
@@ -1,0 +1,22 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_full_text_search_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ pgroonga_condition('PGroonga')
+ AND content &@~ pgroonga_condition(' ');
+
+DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-condition-v2/and/blank/seqscan.sql
+++ b/sql/full-text-search/text/single/query-condition-v2/and/blank/seqscan.sql
@@ -1,0 +1,22 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_full_text_search_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ pgroonga_condition('PGroonga')
+ AND content &@~ pgroonga_condition(' ');
+
+DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-condition-v2/and/blank/seqscan.sql
+++ b/sql/full-text-search/text/single/query-condition-v2/and/blank/seqscan.sql
@@ -16,7 +16,7 @@ SET enable_bitmapscan = off;
 
 SELECT id, content
   FROM memos
- WHERE content &@~ pgroonga_condition('PGroonga')
- AND content &@~ pgroonga_condition(' ');
+ WHERE content &@~ pgroonga_condition('PGroonga') AND
+       content &@~ pgroonga_condition(' ');
 
 DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-v2/and/blank/bitmapscan.sql
+++ b/sql/full-text-search/text/single/query-v2/and/blank/bitmapscan.sql
@@ -1,0 +1,20 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX grnindex ON memos USING pgroonga (content);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga' AND content &@~ ' ';
+
+DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-v2/and/blank/indexscan.sql
+++ b/sql/full-text-search/text/single/query-v2/and/blank/indexscan.sql
@@ -1,0 +1,20 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX grnindex ON memos USING pgroonga (content);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga' AND content &@~ ' ';
+
+DROP TABLE memos;

--- a/sql/full-text-search/text/single/query-v2/and/blank/seqscan.sql
+++ b/sql/full-text-search/text/single/query-v2/and/blank/seqscan.sql
@@ -1,0 +1,20 @@
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX grnindex ON memos USING pgroonga (content);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga' AND content &@~ ' ';
+
+DROP TABLE memos;

--- a/src/pgrn-string.c
+++ b/src/pgrn-string.c
@@ -172,7 +172,7 @@ PGrnStringSubstituteVariables(const char *string,
 }
 
 bool
-PGrnRawStringIsEmpty(const char *string, unsigned int stringSize)
+PGrnStringIsEmpty(const char *string, unsigned int stringSize)
 {
 	grn_raw_string rawString;
 	if (stringSize == 0)

--- a/src/pgrn-string.c
+++ b/src/pgrn-string.c
@@ -170,3 +170,16 @@ PGrnStringSubstituteVariables(const char *string,
 		current += charLength;
 	}
 }
+
+bool
+PGrnRawStringIsEmpty(const char *string, unsigned int stringSize)
+{
+	grn_raw_string rawString;
+	if (stringSize == 0)
+		return true;
+
+	rawString.value = string;
+	rawString.length = stringSize;
+	grn_raw_string_lstrip(ctx, &rawString);
+	return rawString.length == 0;
+}

--- a/src/pgrn-string.h
+++ b/src/pgrn-string.h
@@ -10,4 +10,4 @@ void PGrnStringSubstituteIndex(const char *text,
 void PGrnStringSubstituteVariables(const char *string,
 								   unsigned int stringSize,
 								   grn_obj *output);
-bool PGrnRawStringIsEmpty(const char *string, unsigned int stringSize);
+bool PGrnStringIsEmpty(const char *string, unsigned int stringSize);

--- a/src/pgrn-string.h
+++ b/src/pgrn-string.h
@@ -10,3 +10,4 @@ void PGrnStringSubstituteIndex(const char *text,
 void PGrnStringSubstituteVariables(const char *string,
 								   unsigned int stringSize,
 								   grn_obj *output);
+bool PGrnRawStringIsEmpty(const char *string, unsigned int stringSize);

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -70,6 +70,7 @@
 #include <lib/ilist.h>
 
 #include <groonga.h>
+#include <groonga/plugin.h>
 
 #include <math.h>
 #include <stdlib.h>
@@ -5750,6 +5751,28 @@ PGrnSearchBuildConditionQuery(PGrnSearchData *data,
 	const char *tag = "[build-condition][query]";
 	grn_obj *matchTarget, *matchTargetVariable;
 	grn_expr_flags flags = PGRN_EXPR_QUERY_PARSE_FLAGS;
+
+	if (querySize == 0)
+	{
+		data->isEmptyCondition = true;
+		return;
+	}
+	{
+		unsigned int spaceSize = 0;
+		while (spaceSize < querySize)
+		{
+			unsigned int spaceLength = grn_plugin_isspace(
+				ctx, query + spaceSize, querySize, PGrnGetEncoding());
+			if (spaceLength == 0)
+				break;
+			spaceSize += spaceLength;
+		}
+		if (spaceSize == querySize)
+		{
+			data->isEmptyCondition = true;
+			return;
+		}
+	}
 
 	GRN_EXPR_CREATE_FOR_QUERY(
 		ctx, data->sourcesTable, matchTarget, matchTargetVariable);

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5752,26 +5752,10 @@ PGrnSearchBuildConditionQuery(PGrnSearchData *data,
 	grn_obj *matchTarget, *matchTargetVariable;
 	grn_expr_flags flags = PGRN_EXPR_QUERY_PARSE_FLAGS;
 
-	if (querySize == 0)
+	if (PGrnRawStringIsEmpty(query, querySize))
 	{
 		data->isEmptyCondition = true;
 		return;
-	}
-	{
-		unsigned int spaceSize = 0;
-		while (spaceSize < querySize)
-		{
-			unsigned int spaceLength = grn_plugin_isspace(
-				ctx, query + spaceSize, querySize, PGrnGetEncoding());
-			if (spaceLength == 0)
-				break;
-			spaceSize += spaceLength;
-		}
-		if (spaceSize == querySize)
-		{
-			data->isEmptyCondition = true;
-			return;
-		}
 	}
 
 	GRN_EXPR_CREATE_FOR_QUERY(

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -70,7 +70,6 @@
 #include <lib/ilist.h>
 
 #include <groonga.h>
-#include <groonga/plugin.h>
 
 #include <math.h>
 #include <stdlib.h>

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5752,7 +5752,7 @@ PGrnSearchBuildConditionQuery(PGrnSearchData *data,
 	grn_obj *matchTarget, *matchTargetVariable;
 	grn_expr_flags flags = PGRN_EXPR_QUERY_PARSE_FLAGS;
 
-	if (PGrnRawStringIsEmpty(query, querySize))
+	if (PGrnStringIsEmpty(query, querySize))
 	{
 		data->isEmptyCondition = true;
 		return;

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5505,6 +5505,12 @@ PGrnSearchBuildConditionQueryCondition(PGrnSearchData *data,
 											 &condition,
 											 &matchTarget,
 											 tag);
+	if (PGrnStringIsEmpty(VARDATA_ANY(condition.query),
+						  VARSIZE_ANY_EXHDR(condition.query)))
+	{
+		data->isEmptyCondition = true;
+		return;
+	}
 
 	if (key->sk_strategy == PGrnEqualQueryFTSConditionStrategyV2Number ||
 		key->sk_strategy == PGrnEqualQueryConditionStrategyV2Number)


### PR DESCRIPTION
An error will occur if any of the multiple conditions have a blank space condition.
This is because grn_expr_parse() in PGrnSearchBuildConditionQuery() doesn't add any condition but PGroonga adds logical AND later. Logical AND requires 2 conditions but there is only 1 condition in this case. So the expression becomes invalid.

If the condition contains only blank spaces, there should be no hits, so the result will be empty.