### PR TITLE
ci package: checkout Apache Arrow source

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -146,11 +146,17 @@ jobs:
           - postgresql-12-pgroonga-centos-7
           # Groonga 11.0.5 or later is required
           # - pgroonga-fedora-33
+    env:
+      APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: actions/checkout@v4
+        with:
+          path: apache-arrow
+          repository: apache/arrow
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby


### PR DESCRIPTION
Because Groonga unvendor apache/arrow. We need to checkout apache/arrow manually to build .deb/.rpm packages.

ref: https://github.com/groonga/groonga/pull/1789