### PR TITLE
pgroonga-primary-maintainer: Remove `set -x`

### DIFF
--- a/tools/pgroonga-primary-maintainer.sh
+++ b/tools/pgroonga-primary-maintainer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -xueo pipefail
+set -ueo pipefail
 
 WAL_BLOCK_SIZE=8192
 


### PR DESCRIPTION
Remove debug prints as it is used as a command line tool.