### PR TITLE
pgroonga-primary-maintainer: Remove unnecessary output

### DIFF
--- a/test/test-pgroonga-primary-maintainer.rb
+++ b/test/test-pgroonga-primary-maintainer.rb
@@ -22,6 +22,7 @@ class PGroongaPrimaryMaintainerTestCase < Test::Unit::TestCase
       command = File.join(path, command)
       return command if File.executable?(command)
     end
+    nil
   end
 
   def additional_configurations

--- a/tools/pgroonga-primary-maintainer.sh
+++ b/tools/pgroonga-primary-maintainer.sh
@@ -46,7 +46,7 @@ short_options="t:c:h"
 long_options="threshold:,psql:,help"
 # If you run `getopt` with no arguments and get an error,
 # you are in an environment where the `--longoptions` option is available.
-if getopt > /dev/null; then
+if getopt > /dev/null 2>&1; then
   options=$(getopt "${short_options}" "$@")
 else
   options=$(


### PR DESCRIPTION
Unnecessary errors are displayed, so stderr also redirects to `/dev/null`.