### PR TITLE
Move `which` method to `Helpers::CommandRunnable` as `find_command` method

### DIFF
--- a/test/helpers/sandbox.rb
+++ b/test/helpers/sandbox.rb
@@ -134,6 +134,17 @@ module Helpers
     end
   end
 
+  module LinuxCommand
+    def which(command)
+      ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
+        next unless File.absolute_path?(path)
+        absolute_path_command = File.join(path, command)
+        return absolute_path_command if File.executable?(absolute_path_command)
+      end
+      nil
+    end
+  end
+
   module PlatformDetectable
     private
     def windows?

--- a/test/helpers/sandbox.rb
+++ b/test/helpers/sandbox.rb
@@ -132,10 +132,8 @@ module Helpers
         [output, error]
       end
     end
-  end
 
-  module LinuxCommand
-    def which(command)
+    def find_command(command)
       ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
         next unless File.absolute_path?(path)
         absolute_path_command = File.join(path, command)

--- a/test/test-pgroonga-primary-maintainer.rb
+++ b/test/test-pgroonga-primary-maintainer.rb
@@ -2,6 +2,7 @@ require_relative "helpers/sandbox"
 
 class PGroongaPrimaryMaintainerTestCase < Test::Unit::TestCase
   include Helpers::Sandbox
+  include Helpers::LinuxCommand
 
   PRIMARY_MAINTAINER_COMMAND = "pgroonga-primary-maintainer.sh"
 
@@ -14,15 +15,6 @@ class PGroongaPrimaryMaintainerTestCase < Test::Unit::TestCase
     }
     commane_line = [PRIMARY_MAINTAINER_COMMAND] + options
     run_command(env, *commane_line)
-  end
-
-  def which(command)
-    ENV["PATH"].split(File::PATH_SEPARATOR).each do |path|
-      next unless File.absolute_path?(path)
-      absolute_path_command = File.join(path, command)
-      return absolute_path_command if File.executable?(absolute_path_command)
-    end
-    nil
   end
 
   def additional_configurations

--- a/test/test-pgroonga-primary-maintainer.rb
+++ b/test/test-pgroonga-primary-maintainer.rb
@@ -2,7 +2,6 @@ require_relative "helpers/sandbox"
 
 class PGroongaPrimaryMaintainerTestCase < Test::Unit::TestCase
   include Helpers::Sandbox
-  include Helpers::LinuxCommand
 
   PRIMARY_MAINTAINER_COMMAND = "pgroonga-primary-maintainer.sh"
 
@@ -94,7 +93,7 @@ SELECT name, last_block FROM pgroonga_wal_status()
     end
 
     expected = <<-EXPECTED
-#{which(PRIMARY_MAINTAINER_COMMAND)} --threshold REINDEX_THRESHOLD_SIZE [--psql PSQL_COMMAND_PATH]
+#{find_command(PRIMARY_MAINTAINER_COMMAND)} --threshold REINDEX_THRESHOLD_SIZE [--psql PSQL_COMMAND_PATH]
 
 Options:
 -t, --threshold:


### PR DESCRIPTION
We use `which` in other tests, so we moved it to the helper.