### PR TITLE
pgroonga-generate-primary-maintainer-service: Suppress unnecessary output

### DIFF
--- a/tools/systemd/pgroonga-generate-primary-maintainer-service.sh
+++ b/tools/systemd/pgroonga-generate-primary-maintainer-service.sh
@@ -2,7 +2,7 @@
 
 set -ue
 
-pgroonga_primary_maintainer_command=$(which pgroonga-primary-maintainer.sh || :)
+pgroonga_primary_maintainer_command=$(which pgroonga-primary-maintainer.sh 2>/dev/null || :)
 threshold="1G"
 psql_command=""
 environments=()


### PR DESCRIPTION
Redirect stderr to /dev/null since some environments output stderr when the command is not found.