### PR TITLE
ci: Run primary-maintainer test

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -117,7 +117,11 @@ sudo -u postgres -H \
      --locale=C \
      --pgdata=${data_dir} \
      --username=root
-echo "max_prepared_transactions = 1" | \
+cat <<CONF | \
+  sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
+max_prepared_transactions = 1
+pgroonga.enable_wal = yes
+CONF
   sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
 sudo -u postgres -H \
      $(pg_config --bindir)/pg_ctl start \
@@ -146,6 +150,15 @@ pg_regress=$(dirname $(pg_config --pgxs))/../test/regress/pg_regress
 echo "::endgroup::"
 
 run_test
+
+echo "::group::Run systemd timer test"
+
+$(pg_config --bindir)/createuser postgres --superuser
+/host/packages/test-systemd-timer.sh
+$(pg_config --bindir)/dropuser postgres
+
+echo "::endgroup::"
+
 
 echo "::group::Upgrade"
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -28,6 +28,15 @@ function run_test() {
     chmod -R go+rx /host-rw/logs/
     exit ${pg_regress_status}
   fi
+
+
+  echo "::group::Test primary-maintainer"
+
+  $(pg_config --bindir)/createuser postgres --superuser
+  /host/packages/test-primary-maintainer.sh
+  $(pg_config --bindir)/dropuser postgres
+
+  echo "::endgroup::"
 }
 
 echo "::group::Prepare APT repositories"
@@ -148,15 +157,6 @@ pg_regress=$(dirname $(pg_config --pgxs))/../test/regress/pg_regress
 echo "::endgroup::"
 
 run_test
-
-echo "::group::Test primary-maintainer"
-
-$(pg_config --bindir)/createuser postgres --superuser
-/host/packages/test-primary-maintainer.sh
-$(pg_config --bindir)/dropuser postgres
-
-echo "::endgroup::"
-
 
 echo "::group::Upgrade"
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -152,7 +152,7 @@ run_test
 echo "::group::Run systemd timer test"
 
 $(pg_config --bindir)/createuser postgres --superuser
-/host/packages/test-systemd-timer.sh
+/host/packages/test-primary-maintainer.sh
 $(pg_config --bindir)/dropuser postgres
 
 echo "::endgroup::"

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -149,7 +149,7 @@ echo "::endgroup::"
 
 run_test
 
-echo "::group::Run systemd timer test"
+echo "::group::Test primary-maintainer"
 
 $(pg_config --bindir)/createuser postgres --superuser
 /host/packages/test-primary-maintainer.sh

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -117,12 +117,10 @@ sudo -u postgres -H \
      --locale=C \
      --pgdata=${data_dir} \
      --username=root
-cat <<CONF | \
-  sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
-max_prepared_transactions = 1
-pgroonga.enable_wal = yes
-CONF
-  sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
+{
+  echo "max_prepared_transactions = 1"
+  echo "pgroonga.enable_wal = yes"
+} | sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
 sudo -u postgres -H \
      $(pg_config --bindir)/pg_ctl start \
      --pgdata=${data_dir}

--- a/packages/test-primary-maintainer.sh
+++ b/packages/test-primary-maintainer.sh
@@ -68,6 +68,7 @@ function check_last_block () {
     sleep 1
   done
   systemctl disable --now pgroonga-primary-maintainer.timer
+  sleep 3 # Wait a bit because `primary-maintainer` may be running.
   echo "${ok}"
 }
 

--- a/packages/test-primary-maintainer.sh
+++ b/packages/test-primary-maintainer.sh
@@ -73,7 +73,7 @@ function check_last_block () {
   # failed: Failure due to multiple startup, etc.
   #
   # All status codes are non-zero.
-  while [ -n "$(systemctl is-active pgroonga-primary-maintainer 2>&1 | grep -v inactive 2>&1)" ]; do
+  while [ "$(systemctl is-active pgroonga-primary-maintainer)" = "activating" ]; do
     sleep 1
   done
   echo "${ok}"

--- a/packages/test-primary-maintainer.sh
+++ b/packages/test-primary-maintainer.sh
@@ -68,7 +68,14 @@ function check_last_block () {
     sleep 1
   done
   systemctl disable --now pgroonga-primary-maintainer.timer
-  sleep 3 # Wait a bit because `primary-maintainer` may be running.
+  # activating: Running
+  # inactive: Not running
+  # failed: Failure due to multiple startup, etc.
+  #
+  # All status codes are non-zero.
+  while [ -n "$(systemctl is-active pgroonga-primary-maintainer 2>&1 | grep -v inactive 2>&1)" ]; do
+    sleep 1
+  done
   echo "${ok}"
 }
 

--- a/packages/test-primary-maintainer.sh
+++ b/packages/test-primary-maintainer.sh
@@ -80,7 +80,6 @@ for i in {1..10}; do
   fi
 done
 
-systemctl disable --now pgroonga-primary-maintainer.timer
 rm -f "${SERVICE_PATH}" "${TIMER_PATH}"
 
 sudo -u postgres -H psql --command "DROP DATABASE ${DBNAME};"

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -160,7 +160,7 @@ echo "::endgroup::"
 
 run_test
 
-echo "::group::Run systemd timer test"
+echo "::group::Test primary-maintainer"
 
 $(${pg_config} --bindir)/createuser postgres --superuser
 /host/packages/test-primary-maintainer.sh ${pg_config}

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -117,11 +117,10 @@ sudo -u postgres -H \
      --locale=C \
      --pgdata=${data_dir} \
      --username=root
-cat <<CONF | \
-  sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
-max_prepared_transactions = 1
-pgroonga.enable_wal = yes
-CONF
+{
+  echo "max_prepared_transactions = 1"
+  echo "pgroonga.enable_wal = yes"
+} | sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
 sudo -u postgres -H \
      $(${pg_config} --bindir)/pg_ctl start \
      --pgdata=${data_dir}

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -28,6 +28,15 @@ function run_test() {
     chmod -R go+rx /host-rw/logs/
     exit ${pg_regress_status}
   fi
+
+
+  echo "::group::Test primary-maintainer"
+
+  $(${pg_config} --bindir)/createuser postgres --superuser
+  /host/packages/test-primary-maintainer.sh ${pg_config}
+  $(${pg_config} --bindir)/dropuser postgres
+
+  echo "::endgroup::"
 }
 
 echo "::group::Prepare repositories"
@@ -159,15 +168,6 @@ pg_regress=$(dirname $(${pg_config} --pgxs))/../test/regress/pg_regress
 echo "::endgroup::"
 
 run_test
-
-echo "::group::Test primary-maintainer"
-
-$(${pg_config} --bindir)/createuser postgres --superuser
-/host/packages/test-primary-maintainer.sh ${pg_config}
-$(${pg_config} --bindir)/dropuser postgres
-
-echo "::endgroup::"
-
 
 echo "::group::Upgrade"
 

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -163,7 +163,7 @@ run_test
 echo "::group::Run systemd timer test"
 
 $(${pg_config} --bindir)/createuser postgres --superuser
-/host/packages/test-systemd-timer.sh ${pg_config}
+/host/packages/test-primary-maintainer.sh ${pg_config}
 $(${pg_config} --bindir)/dropuser postgres
 
 echo "::endgroup::"

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -117,8 +117,11 @@ sudo -u postgres -H \
      --locale=C \
      --pgdata=${data_dir} \
      --username=root
-echo "max_prepared_transactions = 1" | \
+cat <<CONF | \
   sudo -u postgres -H tee --append ${data_dir}/postgresql.conf
+max_prepared_transactions = 1
+pgroonga.enable_wal = yes
+CONF
 sudo -u postgres -H \
      $(${pg_config} --bindir)/pg_ctl start \
      --pgdata=${data_dir}
@@ -157,6 +160,15 @@ pg_regress=$(dirname $(${pg_config} --pgxs))/../test/regress/pg_regress
 echo "::endgroup::"
 
 run_test
+
+echo "::group::Run systemd timer test"
+
+$(${pg_config} --bindir)/createuser postgres --superuser
+/host/packages/test-systemd-timer.sh ${pg_config}
+$(${pg_config} --bindir)/dropuser postgres
+
+echo "::endgroup::"
+
 
 echo "::group::Upgrade"
 


### PR DESCRIPTION
Also updated `test-systemd-timer.sh` as it is not stable on CI.

Changed timer enable/disable timing so that `REINDEX` is done after getting before status.
There were cases where `REINDEX` had already ended when the before status was fetched. 