### PR TITLE
ci macos: update bundler cache in each PostgreSQL version

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -110,7 +110,7 @@ jobs:
         with:
           ruby-version: ruby
           bundler-cache: true
-          cache-version: "bundler-cache-${{ matrix.postgresql-version }}"
+          cache-version: ${{ matrix.postgresql-version }}
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           ruby-version: ruby
           bundler-cache: true
+          cache-version: "bundler-cache-${{ matrix.postgresql-version }}"
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
GitHub: fix GH-522

## Issue

`pgroonga-benchmark` gem couldn't run because of the following error. Because the `pg_ext.bundle` in `pg` gem is attempting to load the PostgreSQL 14 library (libpq.5.dylib), while PostgreSQL 15 is installed on the system.

```
pgroonga-benchmark is required: dlopen(/Users/runner/work/pgroonga/pgroonga/vendor/bundle/ruby/3.3.0/gems/pg-1.5.7/lib/pg_ext.bundle, 0x0009): Library not loaded: /opt/homebrew/opt/postgresql@14/lib/postgresql@14/libpq.5.dylib
  Referenced from: <01D03C90-3C16-3457-B7D6-14AB32602E14> /Users/runner/work/pgroonga/pgroonga/vendor/bundle/ruby/3.3.0/gems/pg-1.5.7/lib/pg_ext.bundle
  Reason: tried: '/opt/homebrew/opt/postgresql@14/lib/postgresql@14/libpq.5.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/postgresql@14/lib/postgresql@14/libpq.5.dylib' (no such file), '/opt/homebrew/opt/postgresql@14/lib/postgresql@14/libpq.5.dylib' (no such file) - /Users/runner/work/pgroonga/pgroonga/vendor/bundle/ruby/3.3.0/gems/pg-1.5.7/lib/pg_ext.bundle
```
ref: https://github.com/pgroonga/pgroonga/actions/runs/10190230760/job/28189596781

## The Cause of this issue

The `setup-ruby` action cached gems.
As a result, the `pg` gem is referencing PostgreSQL 14 because it was cached in a previous workflow with PostgreSQL 14. Even if the related PostgreSQL version is updated in new workflow, the `pg` gem isn't changed in the cache because gem isn't updated as it is.

ref: https://github.com/ruby/setup-ruby?tab=readme-ov-file#dealing-with-a-corrupted-cache

## How to resolve

By updating the bundler cache for each PostgreSQL version, this change ensures that the cache does not retain dependencies from different PostgreSQL versions.