### PR TITLE
Remove unnecessary pgroonga_condition() definitions

### DIFF
--- a/data/pgroonga--3.2.1--3.2.2.sql
+++ b/data/pgroonga--3.2.1--3.2.2.sql
@@ -1,1 +1,10 @@
 -- Upgrade SQL
+
+-- Two pgroonga_condition() were defined by a bug in `data/pgroonga--3.2.0--3.2.1.sql`.
+-- Remove unnecessary definitions.
+DROP FUNCTION IF EXISTS pgroonga_condition(query text,
+				   weights int[],
+				   scorers text[],
+				   schema_name text,
+				   index_name text,
+				   column_name text);

--- a/data/pgroonga--3.2.1--3.2.2.sql
+++ b/data/pgroonga--3.2.1--3.2.2.sql
@@ -3,8 +3,8 @@
 -- Two pgroonga_condition() were defined by a bug in `data/pgroonga--3.2.0--3.2.1.sql`.
 -- Remove unnecessary definitions.
 DROP FUNCTION IF EXISTS pgroonga_condition(query text,
-				   weights int[],
-				   scorers text[],
-				   schema_name text,
-				   index_name text,
-				   column_name text);
+					   weights int[],
+					   scorers text[],
+					   schema_name text,
+					   index_name text,
+					   column_name text);

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-function run_test () {
+function run_test() {
   echo "::group::Run test"
 
   set +e

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -158,13 +158,14 @@ if apt show ${pgroonga_package} > /dev/null 2>&1; then
   apt install -V -y \
     ${repositories_dir}/${os}/pool/${code_name}/*/*/*/*_${architecture}.deb
   psql upgrade -c 'ALTER EXTENSION pgroonga UPDATE'
+
+  run_test
 else
   echo "Skip because ${pgroonga_package} hasn't been released yet."
 fi
 
 echo "::endgroup::"
 
-run_test
 
 echo "::group::Postpare"
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -2,6 +2,33 @@
 
 set -eux
 
+function run_test () {
+  echo "::group::Run test"
+
+  set +e
+  ${pg_regress} \
+    --launcher=/host/test/short-pgappname \
+    --load-extension=pgroonga \
+    --schedule=schedule
+  pg_regress_status=$?
+  set -e
+
+  echo "::endgroup::"
+
+
+  if [ ${pg_regress_status} -ne 0 ]; then
+    echo "::group::Diff"
+    cat regression.diffs
+    echo "::endgroup::"
+    mkdir -p /host-rw/logs
+    cp -a regression.diffs /host-rw/logs/
+    cp -a ${data_dir}/log /host-rw/logs/postgresql || :
+    mkdir -p /host-rw/logs/pgroonga/ || :
+    cp -a ${data_dir}/pgroonga.log* /host-rw/logs/pgroonga/ || :
+    chmod -R go+rx /host-rw/logs/
+    exit ${pg_regress_status}
+  fi
+}
 
 echo "::group::Prepare APT repositories"
 
@@ -118,33 +145,7 @@ pg_regress=$(dirname $(pg_config --pgxs))/../test/regress/pg_regress
 
 echo "::endgroup::"
 
-
-echo "::group::Run test"
-
-set +e
-${pg_regress} \
-  --launcher=/host/test/short-pgappname \
-  --load-extension=pgroonga \
-  --schedule=schedule
-pg_regress_status=$?
-set -e
-
-echo "::endgroup::"
-
-
-if [ ${pg_regress_status} -ne 0 ]; then
-  echo "::group::Diff"
-  cat regression.diffs
-  echo "::endgroup::"
-  mkdir -p /host-rw/logs
-  cp -a regression.diffs /host-rw/logs/
-  cp -a ${data_dir}/log /host-rw/logs/postgresql || :
-  mkdir -p /host-rw/logs/pgroonga/ || :
-  cp -a ${data_dir}/pgroonga.log* /host-rw/logs/pgroonga/ || :
-  chmod -R go+rx /host-rw/logs/
-  exit ${pg_regress_status}
-fi
-
+run_test
 
 echo "::group::Upgrade"
 
@@ -163,6 +164,7 @@ fi
 
 echo "::endgroup::"
 
+run_test
 
 echo "::group::Postpare"
 

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-function run_test () {
+function run_test() {
   echo "::group::Run test"
 
   set +e


### PR DESCRIPTION
If you upgrade to 3.2.1 with PGroonga already installed, you get the following error.

```
WHERE content &@~ pgroonga_condition('PGroonga');
                           ^
HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
```

The log also reports the following error.

```
ERROR:  function pgroonga_condition(unknown) is not unique at character 84
```

This is due to a bug in `data/pgroonga--3.2.0--3.2.1.sql` where two pgroonga_condition() were defined.
Therefore, the unnecessary pgroonga_condition() definition was removed.
