### PR TITLE
package: Remove postgresql-13-pgroonga from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,6 @@ def package_names
     "pgroonga",
     "postgresql-12-pgroonga",
     "postgresql-12-pgdg-pgroonga",
-    "postgresql-13-pgroonga",
     "postgresql-13-pgdg-pgroonga",
     "postgresql-14-pgroonga",
     "postgresql-14-pgdg-pgroonga",


### PR DESCRIPTION
Related: ce13d7b3f30ed53b7e0e907c26c5ede47f702d37

It also had to be removed from the Rakefile.