### PR TITLE
tools: Add a script to generate YAML for use with `modifyrepo_c` command

### DIFF
--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -23,8 +23,8 @@ data:
   name: mecab
   stream: "rolling"
   version: $(date "+%Y%m%d")
-  summary: "mecab module in pgroonga local repository"
-  description: "mecab module in pgroonga local repository"
+  summary: "MeCab module in PGroonga local repository"
+  description: "MeCab module in PGroonga local repository"
   license:
     module:
     - GPL-2.0-or-later

--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script is used when building a local repository of RPMs.
+# For modular packages, metadata for them is required.
+# Generate the YAML required when registering that metadata with `modifyrepo_c` command.
+
+set -eu
+
+TARGET_RPM_PREFIXS=(mecab)
+RPM_FILES_DIRECTORY=${1:-.}
+
+cat <<YAML
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: pgroonga
+  stream: "rolling"
+...
+---
+document: modulemd
+version: 2
+data:
+  name: pgroonga
+  stream: "rolling"
+  version: $(date "+%Y%m%d")
+  summary: "pgroonga local repository module"
+  description: "pgroonga local repository module"
+  license:
+    module:
+    - LGPL-2.0-or-later
+  artifacts:
+    rpms:
+YAML
+
+for prefix in "${TARGET_RPM_PREFIXS[@]}"; do
+  for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "${prefix}*.rpm"); do
+    echo "    - $(basename ${rpm_file} | sed 's/.rpm$//')"
+  done
+done
+
+cat <<YAML
+...
+YAML

--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -6,7 +6,6 @@
 
 set -eu
 
-TARGET_RPM_PREFIXES=(mecab)
 RPM_FILES_DIRECTORY=${1:-.}
 
 cat <<YAML
@@ -14,29 +13,29 @@ cat <<YAML
 document: modulemd-defaults
 version: 1
 data:
-  module: pgroonga
+  module: mecab
   stream: "rolling"
 ...
 ---
 document: modulemd
 version: 2
 data:
-  name: pgroonga
+  name: mecab
   stream: "rolling"
   version: $(date "+%Y%m%d")
-  summary: "pgroonga local repository module"
-  description: "pgroonga local repository module"
+  summary: "mecab module in pgroonga local repository"
+  description: "mecab module in pgroonga local repository"
   license:
     module:
-    - LGPL-2.0-or-later
+    - GPL-2.0-or-later
+    - LGPL-2.1-or-later
+    - BSD-3-Clause
   artifacts:
     rpms:
 YAML
 
-for prefix in "${TARGET_RPM_PREFIXES[@]}"; do
-  for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "${prefix}*.rpm"); do
-    echo "    - $(basename ${rpm_file} | sed 's/.rpm$//')"
-  done
+for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "mecab*.rpm"); do
+  echo "    - $(basename ${rpm_file} | sed 's/.rpm$//')"
 done
 
 cat <<YAML

--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -6,7 +6,7 @@
 
 set -eu
 
-TARGET_RPM_PREFIXS=(mecab)
+TARGET_RPM_PREFIXES=(mecab)
 RPM_FILES_DIRECTORY=${1:-.}
 
 cat <<YAML
@@ -33,7 +33,7 @@ data:
     rpms:
 YAML
 
-for prefix in "${TARGET_RPM_PREFIXS[@]}"; do
+for prefix in "${TARGET_RPM_PREFIXES[@]}"; do
   for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "${prefix}*.rpm"); do
     echo "    - $(basename ${rpm_file} | sed 's/.rpm$//')"
   done


### PR DESCRIPTION
When you download the RPM files with `tools/download-rpm.sh` and build a local repository, installing `groonga-tokenizer-mecab` will result in the following error.

```
No available modular metadata for modular package 'mecab-0.996-2.module_el8.6.0+3340+d764b636.x86_64', it cannot be installed on the system
No available modular metadata for modular package 'mecab-ipadic-2.7.0.20070801-16.module_el8.6.0+3340+d764b636.x86_64', it cannot be installed on the system
Error: No available modular metadata for modular package
```

This error occurs because there is no metadata for the modular repository.

Add a script to generate the YAML required when registering metadata with `modifyrepo_c` command.