### PR TITLE
tools/generate-metadata-for-modifyrepo: Set the artifact correctly

### DIFF
--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -35,7 +35,16 @@ data:
 YAML
 
 for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "mecab*.rpm"); do
-  echo "    - $(basename ${rpm_file} | sed 's/.rpm$//')"
+  # Convert
+  # rpm_file (mecab-0.996-2.module_el8.6.0+3340+d764b636.x86_64.rpm)
+  # to
+  # artifact (mecab-0:0.996-2.module_el8.6.0+3340+d764b636.x86_64)
+  #
+  # Add `0:` before the version.
+
+  package_name=$(rpm -qp --queryformat '%{NAME}' ${rpm_file})
+  artifact=$(basename ${rpm_file} | sed -E -e 's/.rpm$//' -e "s/(${package_name})-/\1-0:/")
+  echo "    - ${artifact}"
 done
 
 cat <<YAML

--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -42,7 +42,8 @@ for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "mecab*.rpm"); do
   # rpm_file = mecab-0.996-2.module_el8.6.0+3340+d764b636.x86_64.rpm
   # artifact = mecab-0:0.996-2.module_el8.6.0+3340+d764b636.x86_64
 
-  artifact=$(rpm -qp --queryformat '%{name}-%{epoch}:%{version}-%{release}.%{arch}' ${rpm_file} | sed -e 's/(none)/0/')
+  artifact=$(rpm -qp --queryformat '%{name}-%{epoch}:%{version}-%{release}.%{arch}' ${rpm_file} | \
+               sed -e 's/(none)/0/')
   echo "    - ${artifact}"
 done
 

--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -35,15 +35,14 @@ data:
 YAML
 
 for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "mecab*.rpm"); do
-  # Convert
-  # rpm_file (mecab-0.996-2.module_el8.6.0+3340+d764b636.x86_64.rpm)
-  # to
-  # artifact (mecab-0:0.996-2.module_el8.6.0+3340+d764b636.x86_64)
+  # Convert to artifact.
+  # The difference from the RPM file name is the epoch before the version.
   #
-  # Add `0:` before the version.
+  # Example:
+  # rpm_file = mecab-0.996-2.module_el8.6.0+3340+d764b636.x86_64.rpm
+  # artifact = mecab-0:0.996-2.module_el8.6.0+3340+d764b636.x86_64
 
-  package_name=$(rpm -qp --queryformat '%{NAME}' ${rpm_file})
-  artifact=$(basename ${rpm_file} | sed -E -e 's/.rpm$//' -e "s/(${package_name})-/\1-0:/")
+  artifact=$(rpm -qp --queryformat '%{name}-%{epoch}:%{version}-%{release}.%{arch}' ${rpm_file} | sed -e 's/(none)/0/')
   echo "    - ${artifact}"
 done
 

--- a/tools/generate-metadata-for-modifyrepo.sh
+++ b/tools/generate-metadata-for-modifyrepo.sh
@@ -41,7 +41,6 @@ for rpm_file in $(find ${RPM_FILES_DIRECTORY} -name "mecab*.rpm"); do
   # Example:
   # rpm_file = mecab-0.996-2.module_el8.6.0+3340+d764b636.x86_64.rpm
   # artifact = mecab-0:0.996-2.module_el8.6.0+3340+d764b636.x86_64
-
   artifact=$(rpm -qp --queryformat '%{name}-%{epoch}:%{version}-%{release}.%{arch}' ${rpm_file} | \
                sed -e 's/(none)/0/')
   echo "    - ${artifact}"


### PR DESCRIPTION
It was not a simple file name.

Reference: https://github.com/fedora-modularity/libmodulemd/blob/2.15.0/yaml_specs/modulemd_stream_v2.yaml#L671-L674

```
RPM artifacts shipped with this module
A set of NEVRAs associated with this module. An epoch number in the
NEVRA string is mandatory.
```