### PR TITLE
ci windows: use the latest version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,18 +25,18 @@ jobs:
       matrix:
         include:
           - postgresql-version-major: "12"
-            postgresql-version: "12.19-1"
+            postgresql-version: "12.20-1"
           - postgresql-version-major: "13"
-            postgresql-version: "13.15-1"
+            postgresql-version: "13.16-1"
           - postgresql-version-major: "14"
-            postgresql-version: "14.12-1"
+            postgresql-version: "14.13-1"
           - postgresql-version-major: "15"
-            postgresql-version: "15.7-1"
+            postgresql-version: "15.8-1"
           - postgresql-version-major: "16"
-            postgresql-version: "16.3-1"
+            postgresql-version: "16.4-1"
           - groonga-main: "yes"
             postgresql-version-major: "16"
-            postgresql-version: "16.3-1"
+            postgresql-version: "16.4-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"


### PR DESCRIPTION
PostgreSQL 16.4, 15.8, 14.13, 13.16, and 12.20 has been released at 2024-08-08. 
ref: https://www.postgresql.org/about/news/postgresql-164-158-1413-1316-1220-and-17-beta-3-released-2910/

Tests of Windows that I modified was successful as below.
https://github.com/pgroonga/pgroonga/actions/runs/10311559289