### PR TITLE
Add `pgroonga.*log_rotate_threshold_size` parameter

### DIFF
--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -48,10 +48,8 @@ static char *PGrnLibgroongaVersion;
 
 static bool PGrnEnableWALResourceManager;
 
-#if GRN_VERSION_OR_LATER(14, 0, 7)
 static int PGrnLogRotateThresholdSize;
 static int PGrnQueryLogRotateThresholdSize;
-#endif
 
 static void
 PGrnPostgreSQLLoggerLog(grn_ctx *ctx,
@@ -155,13 +153,19 @@ PGrnLogLevelAssign(int new_value, void *extra)
 	grn_logger_set_max_level(ctx, new_value);
 }
 
-#if GRN_VERSION_OR_LATER(14, 0, 7)
 static void
 PGrnLogRotateThresholdSizeAssign(int new_value, void *extra)
 {
+#if GRN_VERSION_OR_LATER(14, 0, 7)
 	grn_default_logger_set_rotate_threshold_size(new_value);
-}
+#else
+	ereport(ERROR,
+			(errcode(ERRCODE_UNDEFINED_PARAMETER),
+			 errmsg("pgroonga: "
+					"'pgroonga.log_rotate_threshold_size' "
+					"parameter is available with Groonga 14.0.7 or higher.")));
 #endif
+}
 
 static void
 PGrnQueryLogPathAssignRaw(const char *new_value)
@@ -192,13 +196,19 @@ PGrnQueryLogPathAssign(const char *new_value, void *extra)
 	PGrnQueryLogPathAssignRaw(new_value);
 }
 
-#if GRN_VERSION_OR_LATER(14, 0, 7)
 static void
 PGrnQueryLogRotateThresholdSizeAssign(int new_value, void *extra)
 {
+#if GRN_VERSION_OR_LATER(14, 0, 7)
 	grn_default_query_logger_set_rotate_threshold_size(new_value);
-}
+#else
+	ereport(ERROR,
+			(errcode(ERRCODE_UNDEFINED_PARAMETER),
+			 errmsg("pgroonga: "
+					"'pgroonga.query_log_rotate_threshold_size' "
+					"parameter is available with Groonga 14.0.7 or higher.")));
 #endif
+}
 
 static void
 PGrnLockTimeoutAssignRaw(int new_value)
@@ -326,7 +336,6 @@ PGrnInitializeVariables(void)
 							 PGrnLogLevelAssign,
 							 NULL);
 
-#if GRN_VERSION_OR_LATER(14, 0, 7)
 	DefineCustomIntVariable(
 		"pgroonga.log_rotate_threshold_size",
 		"PGroonga log rotation threshold.",
@@ -343,7 +352,6 @@ PGrnInitializeVariables(void)
 		NULL,
 		PGrnLogRotateThresholdSizeAssign,
 		NULL);
-#endif
 
 	DefineCustomStringVariable("pgroonga.query_log_path",
 							   "Query log path for PGroonga.",
@@ -359,7 +367,6 @@ PGrnInitializeVariables(void)
 							   PGrnQueryLogPathAssign,
 							   NULL);
 
-#if GRN_VERSION_OR_LATER(14, 0, 7)
 	DefineCustomIntVariable(
 		"pgroonga.query_log_rotate_threshold_size",
 		"PGroonga query log rotation threshold.",
@@ -376,7 +383,6 @@ PGrnInitializeVariables(void)
 		NULL,
 		PGrnQueryLogRotateThresholdSizeAssign,
 		NULL);
-#endif
 
 	DefineCustomIntVariable("pgroonga.lock_timeout",
 							"Try pgroonga.lock_timeout times "

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -48,6 +48,11 @@ static char *PGrnLibgroongaVersion;
 
 static bool PGrnEnableWALResourceManager;
 
+#if GRN_VERSION_OR_LATER(14, 0, 7)
+static int PGrnLogRotateThresholdSize;
+static int PGrnQueryLogRotateThresholdSize;
+#endif
+
 static void
 PGrnPostgreSQLLoggerLog(grn_ctx *ctx,
 						grn_log_level level,
@@ -150,6 +155,14 @@ PGrnLogLevelAssign(int new_value, void *extra)
 	grn_logger_set_max_level(ctx, new_value);
 }
 
+#if GRN_VERSION_OR_LATER(14, 0, 7)
+static void
+PGrnLogRotateThresholdSizeAssign(int new_value, void *extra)
+{
+	grn_default_logger_set_rotate_threshold_size(new_value);
+}
+#endif
+
 static void
 PGrnQueryLogPathAssignRaw(const char *new_value)
 {
@@ -178,6 +191,14 @@ PGrnQueryLogPathAssign(const char *new_value, void *extra)
 {
 	PGrnQueryLogPathAssignRaw(new_value);
 }
+
+#if GRN_VERSION_OR_LATER(14, 0, 7)
+static void
+PGrnQueryLogRotateThresholdSizeAssign(int new_value, void *extra)
+{
+	grn_default_query_logger_set_rotate_threshold_size(new_value);
+}
+#endif
 
 static void
 PGrnLockTimeoutAssignRaw(int new_value)
@@ -305,6 +326,25 @@ PGrnInitializeVariables(void)
 							 PGrnLogLevelAssign,
 							 NULL);
 
+#if GRN_VERSION_OR_LATER(14, 0, 7)
+	DefineCustomIntVariable(
+		"pgroonga.log_rotate_threshold_size",
+		"PGroonga log rotation threshold.",
+		"Specifies threshold for log rotation. "
+		"Log file is rotated when log file size is larger "
+		"than or equals to the threshold (default: 0; disabled). "
+		"Unit is bytes.",
+		&PGrnLogRotateThresholdSize,
+		grn_default_logger_get_rotate_threshold_size(),
+		0,
+		INT_MAX,
+		PGC_USERSET,
+		GUC_UNIT_BYTE,
+		NULL,
+		PGrnLogRotateThresholdSizeAssign,
+		NULL);
+#endif
+
 	DefineCustomStringVariable("pgroonga.query_log_path",
 							   "Query log path for PGroonga.",
 							   "Path must be a relative path "
@@ -318,6 +358,25 @@ PGrnInitializeVariables(void)
 							   NULL,
 							   PGrnQueryLogPathAssign,
 							   NULL);
+
+#if GRN_VERSION_OR_LATER(14, 0, 7)
+	DefineCustomIntVariable(
+		"pgroonga.query_log_rotate_threshold_size",
+		"PGroonga query log rotation threshold.",
+		"Specifies threshold for query log rotation. "
+		"Query log file is rotated when query log file size is "
+		"larger than or equals to the threshold (default: 0; disabled). "
+		"Unit is bytes.",
+		&PGrnQueryLogRotateThresholdSize,
+		grn_default_query_logger_get_rotate_threshold_size(),
+		0,
+		INT_MAX,
+		PGC_USERSET,
+		GUC_UNIT_BYTE,
+		NULL,
+		PGrnQueryLogRotateThresholdSizeAssign,
+		NULL);
+#endif
 
 	DefineCustomIntVariable("pgroonga.lock_timeout",
 							"Try pgroonga.lock_timeout times "

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -156,6 +156,9 @@ PGrnLogLevelAssign(int new_value, void *extra)
 static void
 PGrnLogRotateThresholdSizeAssign(int new_value, void *extra)
 {
+	if (new_value == grn_default_logger_get_rotate_threshold_size())
+		return;
+
 #if GRN_VERSION_OR_LATER(14, 0, 7)
 	grn_default_logger_set_rotate_threshold_size(new_value);
 #else
@@ -199,6 +202,9 @@ PGrnQueryLogPathAssign(const char *new_value, void *extra)
 static void
 PGrnQueryLogRotateThresholdSizeAssign(int new_value, void *extra)
 {
+	if (new_value == grn_default_query_logger_get_rotate_threshold_size())
+		return;
+
 #if GRN_VERSION_OR_LATER(14, 0, 7)
 	grn_default_query_logger_set_rotate_threshold_size(new_value);
 #else

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -156,17 +156,18 @@ PGrnLogLevelAssign(int new_value, void *extra)
 static void
 PGrnLogRotateThresholdSizeAssign(int new_value, void *extra)
 {
-	if (new_value == grn_default_logger_get_rotate_threshold_size())
-		return;
-
 #if GRN_VERSION_OR_LATER(14, 0, 7)
 	grn_default_logger_set_rotate_threshold_size(new_value);
 #else
-	ereport(ERROR,
+	if (new_value != grn_default_logger_get_rotate_threshold_size())
+	{
+		ereport(
+			ERROR,
 			(errcode(ERRCODE_UNDEFINED_PARAMETER),
 			 errmsg("pgroonga: "
 					"'pgroonga.log_rotate_threshold_size' "
 					"parameter is available with Groonga 14.0.7 or higher.")));
+	}
 #endif
 }
 
@@ -202,17 +203,18 @@ PGrnQueryLogPathAssign(const char *new_value, void *extra)
 static void
 PGrnQueryLogRotateThresholdSizeAssign(int new_value, void *extra)
 {
-	if (new_value == grn_default_query_logger_get_rotate_threshold_size())
-		return;
-
 #if GRN_VERSION_OR_LATER(14, 0, 7)
 	grn_default_query_logger_set_rotate_threshold_size(new_value);
 #else
-	ereport(ERROR,
+	if (new_value != grn_default_query_logger_get_rotate_threshold_size())
+	{
+		ereport(
+			ERROR,
 			(errcode(ERRCODE_UNDEFINED_PARAMETER),
 			 errmsg("pgroonga: "
 					"'pgroonga.query_log_rotate_threshold_size' "
 					"parameter is available with Groonga 14.0.7 or higher.")));
+	}
 #endif
 }
 

--- a/test/test-pgroonga-parameter.rb
+++ b/test/test-pgroonga-parameter.rb
@@ -69,10 +69,10 @@ pgroonga.log_rotate_threshold_size = 10
     end
 
     test "rotated" do
-      before_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.log*")
       run_sql("SELECT pgroonga_command('status');")
-      after_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.log*")
-      assert_true(before_log_files.size < after_log_files.size)
+      assert do
+        not Pathname.glob("#{@postgresql.dir}/pgroonga.log.*").empty?
+      end
     end
   end
 
@@ -89,10 +89,10 @@ pgroonga.query_log_path = 'pgroonga.query.log'
     end
 
     test "rotated" do
-      before_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.query.log*")
       run_sql("SELECT pgroonga_command('status');")
-      after_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.query.log*")
-      assert_true(before_log_files.size < after_log_files.size)
+      assert do
+        not Pathname.glob("#{@postgresql.dir}/pgroonga.query.log.*").empty?
+      end
     end
   end
 end

--- a/test/test-pgroonga-parameter.rb
+++ b/test/test-pgroonga-parameter.rb
@@ -60,12 +60,11 @@ pgroonga.log_type = postgresql
   sub_test_case "pgroonga.log_rotate_threshold_size" do
     setup do
       require_groonga_version(14, 0, 7)
-    end
-
-    def additional_configurations
-      <<-CONFIG
+      stop_postgres
+      @postgresql.append_configuration(<<-CONFIG)
 pgroonga.log_rotate_threshold_size = 10
       CONFIG
+      start_postgres
     end
 
     test "rotated" do
@@ -79,13 +78,12 @@ pgroonga.log_rotate_threshold_size = 10
   sub_test_case "pgroonga.query_log_rotate_threshold_size" do
     setup do
       require_groonga_version(14, 0, 7)
-    end
-
-    def additional_configurations
-      <<-CONFIG
+      stop_postgres
+      @postgresql.append_configuration(<<-CONFIG)
 pgroonga.query_log_rotate_threshold_size = 10
 pgroonga.query_log_path = 'pgroonga.query.log'
       CONFIG
+      start_postgres
     end
 
     test "rotated" do

--- a/test/test-pgroonga-parameter.rb
+++ b/test/test-pgroonga-parameter.rb
@@ -56,4 +56,43 @@ pgroonga.log_type = postgresql
       end
     end
   end
+
+  sub_test_case "pgroonga.log_rotate_threshold_size" do
+    setup do
+      require_groonga_version(14, 0, 7)
+    end
+
+    def additional_configurations
+      <<-CONFIG
+pgroonga.log_rotate_threshold_size = 10
+      CONFIG
+    end
+
+    test "rotated" do
+      before_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.log*")
+      run_sql("SELECT pgroonga_command('status');")
+      after_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.log*")
+      assert_true(before_log_files.size < after_log_files.size)
+    end
+  end
+
+  sub_test_case "pgroonga.query_log_rotate_threshold_size" do
+    setup do
+      require_groonga_version(14, 0, 7)
+    end
+
+    def additional_configurations
+      <<-CONFIG
+pgroonga.query_log_rotate_threshold_size = 10
+pgroonga.query_log_path = 'pgroonga.query.log'
+      CONFIG
+    end
+
+    test "rotated" do
+      before_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.query.log*")
+      run_sql("SELECT pgroonga_command('status');")
+      after_log_files = Pathname.glob("#{@postgresql.dir}/pgroonga.query.log*")
+      assert_true(before_log_files.size < after_log_files.size)
+    end
+  end
 end


### PR DESCRIPTION
GitHub: fixes GH-532

PGroonga's logs are also rotated using Groonga's log rotation.

It is available in Groonga 14.0.7 or later because there is a bug in Groonga 14.0.6 or earlier.