### PR TITLE
Fix bug that log_level is not reflected

### DIFF
--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -137,7 +137,7 @@ PGrnLogPathAssign(const char *new_value, void *extra)
 static void
 PGrnLogLevelAssign(int new_value, void *extra)
 {
-	grn_default_logger_set_max_level(new_value);
+	grn_logger_set_max_level(ctx, new_value);
 }
 
 static void

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -100,7 +100,8 @@ PGrnLogTypeAssign(int new_value, void *extra)
 		grn_logger_set(ctx, &PGrnPostgreSQLLogger);
 		break;
 	default:
-		grn_logger_set(ctx, NULL);
+		if (PGrnGroongaInitialized)
+			grn_logger_set(ctx, NULL);
 		break;
 	}
 }
@@ -137,6 +138,7 @@ PGrnLogPathAssign(const char *new_value, void *extra)
 static void
 PGrnLogLevelAssign(int new_value, void *extra)
 {
+	grn_default_logger_set_max_level(new_value);
 	grn_logger_set_max_level(ctx, new_value);
 }
 

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -138,6 +138,14 @@ PGrnLogPathAssign(const char *new_value, void *extra)
 static void
 PGrnLogLevelAssign(int new_value, void *extra)
 {
+	/*
+	 * If `pgroonga.log_type` is not specified, Groonga's default logger is
+	 * used. grn_default_logger_set_max_level() is required for it.
+	 *
+	 * If `pgroonga.log_type` is specified, set the logger with
+	 * grn_logger_set(). In that case, use grn_logger_set_max_level() to change
+	 * the setting.
+	 */
 	grn_default_logger_set_max_level(new_value);
 	grn_logger_set_max_level(ctx, new_value);
 }

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -677,15 +677,15 @@ _PG_init(void)
 		PGrnBaseInitialized = false;
 		PGrnGroongaInitialized = false;
 
+		rc = grn_init();
+		PGrnCheckRC(rc, "failed to initialize Groonga");
+
 		PGrnInitializeVariables();
 
 		grn_thread_set_get_limit_func(PGrnGetThreadLimit, NULL);
 
 		grn_default_logger_set_flags(grn_default_logger_get_flags() |
 									 GRN_LOG_PID);
-
-		rc = grn_init();
-		PGrnCheckRC(rc, "failed to initialize Groonga");
 
 		grn_set_segv_handler();
 		grn_set_abrt_handler();

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -677,15 +677,15 @@ _PG_init(void)
 		PGrnBaseInitialized = false;
 		PGrnGroongaInitialized = false;
 
-		rc = grn_init();
-		PGrnCheckRC(rc, "failed to initialize Groonga");
-
 		PGrnInitializeVariables();
 
 		grn_thread_set_get_limit_func(PGrnGetThreadLimit, NULL);
 
 		grn_default_logger_set_flags(grn_default_logger_get_flags() |
 									 GRN_LOG_PID);
+
+		rc = grn_init();
+		PGrnCheckRC(rc, "failed to initialize Groonga");
 
 		grn_set_segv_handler();
 		grn_set_abrt_handler();

--- a/test/test-pgroonga-parameter.rb
+++ b/test/test-pgroonga-parameter.rb
@@ -1,0 +1,47 @@
+require_relative "helpers/sandbox"
+
+class PGroongaParameterTestCase < Test::Unit::TestCase
+  include Helpers::Sandbox
+
+  sub_test_case "pgroonga.log_type = file" do
+    sub_test_case "pgroonga.log_level = debug" do
+      def additional_configurations
+        <<-CONFIG
+pgroonga.log_type = file
+pgroonga.log_level = debug
+        CONFIG
+      end
+
+      test "log output" do
+        pgroonga_log = @postgresql.read_pgroonga_log
+        assert_false(pgroonga_log.scan(/\|d\|.*pgroonga:/).empty?,
+                      pgroonga_log)
+
+        postgresql_log = @postgresql.read_log
+        assert_true(postgresql_log.scan(/pgroonga:log:.*\|d\| pgroonga:/).empty?,
+                    postgresql_log)
+      end
+    end
+  end
+
+  sub_test_case "pgroonga.log_type = postgresql" do
+    sub_test_case "pgroonga.log_level = debug" do
+      def additional_configurations
+        <<-CONFIG
+pgroonga.log_type = postgresql
+pgroonga.log_level = debug
+        CONFIG
+      end
+
+      test "log output" do
+        pgroonga_log = @postgresql.read_pgroonga_log
+        assert_true(pgroonga_log.scan(/\|d\|.*pgroonga:/).empty?,
+                      pgroonga_log)
+
+        postgresql_log = @postgresql.read_log
+        assert_false(postgresql_log.scan(/pgroonga:log:.*\|d\| pgroonga:/).empty?,
+                    postgresql_log)
+      end
+    end
+  end
+end

--- a/test/test-pgroonga-parameter.rb
+++ b/test/test-pgroonga-parameter.rb
@@ -4,7 +4,10 @@ class PGroongaParameterTestCase < Test::Unit::TestCase
   include Helpers::Sandbox
 
   setup do
-    @debug_log_pattern = /\|d\|.*:(set_normalizers NormalizerAuto)/
+    @debug_log_pattern = {
+      pgroonga_log: /\|d\|\d+: (.*)$/,
+      postgresql_log: /\|d\| (.*) \d+$/,
+    }
   end
 
   sub_test_case "pgroonga.log_type = file" do
@@ -18,13 +21,14 @@ pgroonga.log_level = debug
 
       test "log output" do
         pgroonga_log = @postgresql.read_pgroonga_log
-        assert_equal([["set_normalizers NormalizerAuto"], ["set_normalizers NormalizerAuto"]],
-                     pgroonga_log.scan(@debug_log_pattern),
+        assert_equal(["DDL:2147483654:set_normalizers NormalizerAuto"],
+                     pgroonga_log.scan(@debug_log_pattern[:pgroonga_log]).first,
                      pgroonga_log)
 
         postgresql_log = @postgresql.read_log
-        assert_true(postgresql_log.scan(@debug_log_pattern).empty?,
-                    postgresql_log)
+        assert_equal([],
+                     postgresql_log.scan(@debug_log_pattern[:postgresql_log]),
+                     postgresql_log)
       end
     end
   end
@@ -40,12 +44,13 @@ pgroonga.log_level = debug
 
       test "log output" do
         pgroonga_log = @postgresql.read_pgroonga_log
-        assert_true(pgroonga_log.scan(@debug_log_pattern).empty?,
-                    pgroonga_log)
+        assert_equal([],
+                     pgroonga_log.scan(@debug_log_pattern[:pgroonga_log]),
+                     pgroonga_log)
 
         postgresql_log = @postgresql.read_log
-        assert_equal([["set_normalizers NormalizerAuto"], ["set_normalizers NormalizerAuto"]],
-                     postgresql_log.scan(@debug_log_pattern),
+        assert_equal(["DDL:2147483654:set_normalizers NormalizerAuto"],
+                     postgresql_log.scan(@debug_log_pattern[:postgresql_log]).first,
                      postgresql_log)
       end
     end

--- a/test/test-pgroonga-parameter.rb
+++ b/test/test-pgroonga-parameter.rb
@@ -3,6 +3,10 @@ require_relative "helpers/sandbox"
 class PGroongaParameterTestCase < Test::Unit::TestCase
   include Helpers::Sandbox
 
+  setup do
+    @debug_log_pattern = /\|d\|.*:(set_normalizers NormalizerAuto)/
+  end
+
   sub_test_case "pgroonga.log_type = file" do
     sub_test_case "pgroonga.log_level = debug" do
       def additional_configurations
@@ -14,11 +18,12 @@ pgroonga.log_level = debug
 
       test "log output" do
         pgroonga_log = @postgresql.read_pgroonga_log
-        assert_false(pgroonga_log.scan(/\|d\|.*pgroonga:/).empty?,
-                      pgroonga_log)
+        assert_equal([["set_normalizers NormalizerAuto"], ["set_normalizers NormalizerAuto"]],
+                     pgroonga_log.scan(@debug_log_pattern),
+                     pgroonga_log)
 
         postgresql_log = @postgresql.read_log
-        assert_true(postgresql_log.scan(/pgroonga:log:.*\|d\| pgroonga:/).empty?,
+        assert_true(postgresql_log.scan(@debug_log_pattern).empty?,
                     postgresql_log)
       end
     end
@@ -35,12 +40,13 @@ pgroonga.log_level = debug
 
       test "log output" do
         pgroonga_log = @postgresql.read_pgroonga_log
-        assert_true(pgroonga_log.scan(/\|d\|.*pgroonga:/).empty?,
-                      pgroonga_log)
+        assert_true(pgroonga_log.scan(@debug_log_pattern).empty?,
+                    pgroonga_log)
 
         postgresql_log = @postgresql.read_log
-        assert_false(postgresql_log.scan(/pgroonga:log:.*\|d\| pgroonga:/).empty?,
-                    postgresql_log)
+        assert_equal([["set_normalizers NormalizerAuto"], ["set_normalizers NormalizerAuto"]],
+                     postgresql_log.scan(@debug_log_pattern),
+                     postgresql_log)
       end
     end
   end


### PR DESCRIPTION
This is a bug that occurs when `pgroonga.log_type = postgresql`.
The change in `log_level` was not reflected in the output.

For example, setting to `pgroonga.log_level = debug` did not output debug logs.