### PR TITLE
test: Use `windows?` instead of `Gem.win_platform?`

### DIFF
--- a/test/test-pgroonga-primary-maintainer.rb
+++ b/test/test-pgroonga-primary-maintainer.rb
@@ -21,7 +21,7 @@ class PGroongaPrimaryMaintainerTestCase < Test::Unit::TestCase
   end
 
   setup do
-    omit("Omit on Windows: Bash scripts cannot be run.") if Gem.win_platform?
+    omit("Omit on Windows: Bash scripts cannot be run.") if windows?
 
     run_sql("CREATE TABLE notes (content text);")
     run_sql("CREATE INDEX notes_content ON notes USING pgroonga (content);")

--- a/test/test-query-expand.rb
+++ b/test/test-query-expand.rb
@@ -17,7 +17,7 @@ class QueryExpandTestCase < Test::Unit::TestCase
 
   sub_test_case("Sudachi") do
     setup do
-      if Gem.win_platform?
+      if windows?
         omit("Can't use multibyte characters on Windows")
       end
       run_sql(<<-SQL)


### PR DESCRIPTION
`windows?` defined in `test/helpers/sandbox.rb`.
In the testing of this repository, we use `windows?`, so we will unify the use of it.