### PR TITLE
variables: logging settings: Check Groonga version at runtime, not at build time

### DIFF
--- a/src/pgrn-groonga.h
+++ b/src/pgrn-groonga.h
@@ -63,6 +63,20 @@ PGrnInspectName(grn_obj *object)
 	return name;
 }
 
+static inline bool
+PGrnGroongaVersionOrLater(uint32_t major, uint32_t minor, uint32_t micro)
+{
+	// Same as GRN_VERSION_OR_LATER() in Groonga.
+	uint32_t grn_version_major = grn_get_version_major();
+	uint32_t grn_version_minor = grn_get_version_minor();
+	uint32_t grn_version_micro = grn_get_version_micro();
+
+	return (grn_version_major > major ||
+			(grn_version_major == major && grn_version_minor > minor) ||
+			(grn_version_major == major && grn_version_minor == minor &&
+			 grn_version_micro >= micro));
+}
+
 static inline grn_encoding
 PGrnPGEncodingToGrnEncoding(int pgEncoding)
 {

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -109,9 +109,8 @@ PGrnLogTypeAssign(int new_value, void *extra)
 		 * (= Do not run grn_logger_set() before PGrnGroongaInitialized.)
 		 * Because it crashes on Windows under Groonga 14.0.8.
 		 */
-		if (!PGrnGroongaInitialized && !PGrnGroongaVersionOrLater(14, 0, 8))
-			break;
-		grn_logger_set(ctx, NULL);
+		if (PGrnGroongaVersionOrLater(14, 0, 8) || PGrnGroongaInitialized)
+			grn_logger_set(ctx, NULL);
 		break;
 	}
 }

--- a/src/pgrn-variables.c
+++ b/src/pgrn-variables.c
@@ -2,6 +2,7 @@
 
 #include "pgrn-compatible.h"
 #include "pgrn-global.h"
+#include "pgrn-groonga.h"
 #include "pgrn-log-level.h"
 #include "pgrn-row-level-security.h"
 #include "pgrn-trace-log.h"
@@ -103,19 +104,14 @@ PGrnLogTypeAssign(int new_value, void *extra)
 		grn_logger_set(ctx, &PGrnPostgreSQLLogger);
 		break;
 	default:
-#if !GRN_VERSION_OR_LATER(14, 0, 8)
 		/*
 		 * grn_logger_set() is not run to set the default value.
 		 * (= Do not run grn_logger_set() before PGrnGroongaInitialized.)
 		 * Because it crashes on Windows under Groonga 14.0.8.
 		 */
-		if (PGrnGroongaInitialized)
-		{
-#endif
-			grn_logger_set(ctx, NULL);
-#if !GRN_VERSION_OR_LATER(14, 0, 8)
-		}
-#endif
+		if (!PGrnGroongaInitialized && !PGrnGroongaVersionOrLater(14, 0, 8))
+			break;
+		grn_logger_set(ctx, NULL);
 		break;
 	}
 }
@@ -152,7 +148,6 @@ PGrnLogPathAssign(const char *new_value, void *extra)
 static void
 PGrnLogLevelAssign(int new_value, void *extra)
 {
-#if !GRN_VERSION_OR_LATER(14, 0, 8)
 	/*
 	 * If `pgroonga.log_type` is not specified, Groonga's default logger is
 	 * used. grn_default_logger_set_max_level() is required for it.
@@ -163,8 +158,8 @@ PGrnLogLevelAssign(int new_value, void *extra)
 	 *
 	 * See also the comments on PGrnLogTypeAssign().
 	 */
-	grn_default_logger_set_max_level(new_value);
-#endif
+	if (!PGrnGroongaVersionOrLater(14, 0, 8))
+		grn_default_logger_set_max_level(new_value);
 	grn_logger_set_max_level(ctx, new_value);
 }
 


### PR DESCRIPTION
You can use the features by upgrading only Groonga without rebuilding PGroonga.