### PR TITLE
ci windows: add support for PostgreSQL 17

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,9 +34,11 @@ jobs:
             postgresql-version: "15.8-1"
           - postgresql-version-major: "16"
             postgresql-version: "16.4-1"
+          - postgresql-version-major: "17"
+            postgresql-version: "17.0-1"
           - groonga-main: "yes"
-            postgresql-version-major: "16"
-            postgresql-version: "16.4-1"
+            postgresql-version-major: "17"
+            postgresql-version: "17.0-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"
@@ -197,7 +199,11 @@ jobs:
           }
           ruby test\prepare.rb > schedule
           $Env:PG_REGRESS_DIFF_OPTS = "-u"
-          ..\pgsql\bin\pg_regress `
+          $PG_REGRESS = "..\pgsql\lib\pgxs\src\test\regress\pg_regress"
+          if (${{ matrix.postgresql-version-major }} -lt 17) {
+            $PG_REGRESS = "..\pgsql\bin\pg_regress"
+          }
+          & $PG_REGRESS `
             --bindir=..\pgsql\bin `
             --encoding=${Env:PGROONGA_TEST_ENCODING} `
             --launcher=test\short-pgappname.bat `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -199,7 +199,7 @@ jobs:
           }
           ruby test\prepare.rb > schedule
           $Env:PG_REGRESS_DIFF_OPTS = "-u"
-          if (${{ matrix.postgresql-version-major }} -gt 17) {
+          if (${{ matrix.postgresql-version-major }} -ge 17) {
             # pg_regress.exe depends on libpq.dll and libpq.dll exists
             # in pgsql\bin\. We need to set $Env:PATH or use same
             # directory to resolve the dependency. We use the same

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -199,11 +199,16 @@ jobs:
           }
           ruby test\prepare.rb > schedule
           $Env:PG_REGRESS_DIFF_OPTS = "-u"
-          $PG_REGRESS = "..\pgsql\lib\pgxs\src\test\regress\pg_regress"
-          if (${{ matrix.postgresql-version-major }} -lt 17) {
-            $PG_REGRESS = "..\pgsql\bin\pg_regress"
+          if (${{ matrix.postgresql-version-major }} -gt 17) {
+            # pg_regress.exe depends on libpq.dll and libpq.dll exists
+            # in pgsql\bin\. We need to set $Env:PATH or use same
+            # directory to resolve the dependency. We use the same
+            # directory approach here.
+            Copy-Item `
+              -Path ..\pgsql\lib\pgxs\src\test\regress\pg_regress.exe `
+              ..\pgsql\bin\
           }
-          & $PG_REGRESS `
+          ..\pgsql\bin\pg_regress `
             --bindir=..\pgsql\bin `
             --encoding=${Env:PGROONGA_TEST_ENCODING} `
             --launcher=test\short-pgappname.bat `


### PR DESCRIPTION
GitHub: GH-552

This is part of the task of adding support for PostgreSQL 17.

We use released PostgreSQL 17 not unreleased PostgreSQL 17 for Windows by this PR.