### PR TITLE
ci macos: add support for PostgreSQL 17

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,8 +51,9 @@ jobs:
               sort --version-sort | \
               head -n1 \
           )
-          if [ "${older_groonga_version}" = "${homebrew_groonga_version}" ] && \
-             [ "${homebrew_groonga_version}" != "${required_groonga_version}" ]; then
+          if ([ "${older_groonga_version}" = "${homebrew_groonga_version}" ] && \
+              [ "${homebrew_groonga_version}" != "${required_groonga_version}" ]) || \
+             ! brew info postgresql@${{ matrix.postgresql-version }}; then
             brew update
             # Force overwriting Python related symbolic links because
             # Python related files in $(brew --prefix)/bin/ are provided

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,6 +28,7 @@ jobs:
           - "14"
           - "15"
           - "16"
+          - "17"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}/pgroonga-benchmark/Gemfile
     runs-on: macos-latest


### PR DESCRIPTION
GitHub: GH-552

This is part of the task of adding support for PostgreSQL 17.

We add support for PostgreSQL 17 on CI of macOS workflow by this PR.