### PR TITLE
packages ubuntu noble: add support for PostgreSQL 17

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,6 +83,8 @@ jobs:
           - postgresql-17-pgdg-pgroonga-ubuntu-focal-arm64
           - postgresql-17-pgdg-pgroonga-ubuntu-jammy
           - postgresql-17-pgdg-pgroonga-ubuntu-jammy-arm64
+          - postgresql-17-pgdg-pgroonga-ubuntu-noble
+          - postgresql-17-pgdg-pgroonga-ubuntu-noble-arm64
           - postgresql-16-pgdg-pgroonga-debian-bookworm
           - postgresql-16-pgdg-pgroonga-debian-bookworm-arm64
           - postgresql-16-pgdg-pgroonga-ubuntu-focal

--- a/packages/postgresql-17-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-17-pgdg-pgroonga/Rakefile
@@ -13,6 +13,8 @@ class PostgreSQL17PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
       "ubuntu-focal-arm64",
       "ubuntu-jammy",
       "ubuntu-jammy-arm64",
+      "ubuntu-noble",
+      "ubuntu-noble-arm64",
     ]
   end
 

--- a/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,0 +1,1 @@
+arm64v8/ubuntu:noble

--- a/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-noble/Dockerfile
+++ b/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-noble/Dockerfile
@@ -1,0 +1,41 @@
+ARG FROM=ubuntu:noble
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+ARG POSTGRESQL_VERSION
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    gnupg \
+    lsb-release \
+    software-properties-common \
+    wget && \
+  add-apt-repository -y universe && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release --codename --short)-pgdg main" > \
+    /etc/apt/sources.list.d/pgdg.list && \
+  wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+    apt-key add - && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    libmsgpack-dev \
+    libxxhash-dev \
+    pkg-config \
+    postgresql-server-dev-${POSTGRESQL_VERSION} && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN { \
+      echo "DEBUILD_LINTIAN=no"; \
+    } > ~/.devscripts


### PR DESCRIPTION
GitHub: GH-552

This is part of the task of adding support for PostgreSQL 17.

We add support for PostgreSQL 17 on Ubuntu noble by this PR.