### PR TITLE
packages apt: use --platform=linux/arm64 explicitly

### DIFF
--- a/packages/postgresql-12-pgdg-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-12-pgdg-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
+++ b/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:focal
+--platform=linux/arm64 arm64v8/ubuntu:focal

--- a/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:jammy
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-12-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:noble
+--platform=linux/arm64 arm64v8/ubuntu:noble

--- a/packages/postgresql-13-pgdg-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-13-pgdg-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
+++ b/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:focal
+--platform=linux/arm64 arm64v8/ubuntu:focal

--- a/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:jammy
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-13-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:noble
+--platform=linux/arm64 arm64v8/ubuntu:noble

--- a/packages/postgresql-14-pgdg-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-14-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:focal
+--platform=linux/arm64 arm64v8/ubuntu:focal

--- a/packages/postgresql-14-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:jammy
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/postgresql-14-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:noble
+--platform=linux/arm64 arm64v8/ubuntu:noble

--- a/packages/postgresql-15-pgdg-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-15-pgdg-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-15-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
+++ b/packages/postgresql-15-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:focal
+--platform=linux/arm64 arm64v8/ubuntu:focal

--- a/packages/postgresql-15-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-15-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:jammy
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/postgresql-15-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-15-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:noble
+--platform=linux/arm64 arm64v8/ubuntu:noble

--- a/packages/postgresql-15-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-15-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-16-pgdg-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-16-pgdg-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-16-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
+++ b/packages/postgresql-16-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:focal
+--platform=linux/arm64 arm64v8/ubuntu:focal

--- a/packages/postgresql-16-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-16-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:jammy
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/postgresql-16-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-16-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:noble
+--platform=linux/arm64 arm64v8/ubuntu:noble

--- a/packages/postgresql-17-pgdg-pgroonga/apt/debian-bookworm-arm64/from
+++ b/packages/postgresql-17-pgdg-pgroonga/apt/debian-bookworm-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/debian:bookworm
+--platform=linux/arm64 arm64v8/debian:bookworm

--- a/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
+++ b/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-focal-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:focal
+--platform=linux/arm64 arm64v8/ubuntu:focal

--- a/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
+++ b/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-jammy-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:jammy
+--platform=linux/arm64 arm64v8/ubuntu:jammy

--- a/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
+++ b/packages/postgresql-17-pgdg-pgroonga/apt/ubuntu-noble-arm64/from
@@ -1,1 +1,1 @@
-arm64v8/ubuntu:noble
+--platform=linux/arm64 arm64v8/ubuntu:noble


### PR DESCRIPTION
Because of build failure.

Example of error:

```
ERROR: failed to solve: arm64v8/ubuntu:focal: failed to resolve source metadata for docker.io/arm64v8/ubuntu:focal: no match for platform in manifest: not found
```