### PR TITLE
ci: Run all tests, on a periodic run by schedule

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -159,4 +159,4 @@ jobs:
               test/run-test.rb -v
         env:
           # When scheduled execution, all tests are run.
-          CI: github.event_name != 'schedule'
+          CI: ${{ github.event_name != 'schedule' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,8 +9,10 @@ on:
     branches:
       - "*"
   schedule:
+    # * UTC 16:30
+    # * JST 01:30
     - cron: |
-        0 0 * * *
+        30 16 * * *
 jobs:
   test:
     if: >-
@@ -18,7 +20,7 @@ jobs:
       (github.event_name == 'schedule' &&
        github.repository_owner == 'pgroonga')
     name: Test
-    timeout-minutes: 30
+    timeout-minutes: ${{ github.event_name == 'schedule' && 150 || 30 }}
     strategy:
       fail-fast: false
       matrix:
@@ -155,3 +157,6 @@ jobs:
             bundle exec ruby \
               -I${{ github.workspace }}/pgroonga-benchmark/lib \
               test/run-test.rb -v
+        env:
+          # When scheduled execution, all tests are run.
+          CI: github.event_name != 'schedule'

--- a/test/test-pgroonga-check.rb
+++ b/test/test-pgroonga-check.rb
@@ -151,7 +151,7 @@ SELECT * FROM memos WHERE content %% 'PGroonga';
 
   sub_test_case "list-broken-indexes" do
     test "corrupt" do
-      omit("This test takes over 10 minutes, so skip it.") if ENV["CI"] == "true"
+      omit("This test takes over 10 minutes.") if ENV["CI"] == "true"
 
       run_sql("CREATE TABLE memos (content text);")
       run_sql("CREATE INDEX memos_content ON memos USING pgroonga (content);")

--- a/test/test-pgroonga-check.rb
+++ b/test/test-pgroonga-check.rb
@@ -151,7 +151,7 @@ SELECT * FROM memos WHERE content %% 'PGroonga';
 
   sub_test_case "list-broken-indexes" do
     test "corrupt" do
-      omit("This test takes over 10 minutes, so skip it.") if ENV["CI"]
+      omit("This test takes over 10 minutes, so skip it.") if ENV["CI"] == "true"
 
       run_sql("CREATE TABLE memos (content text);")
       run_sql("CREATE INDEX memos_content ON memos USING pgroonga (content);")

--- a/test/test-pgroonga-check.rb
+++ b/test/test-pgroonga-check.rb
@@ -167,7 +167,7 @@ SELECT * FROM memos WHERE content %% 'PGroonga';
         input.puts(<<-"SQL")
 SELECT path
 FROM (
-  SELECT value->1 name, value->2 path
+  SELECT value->1 AS name, value->2 AS path
   FROM JSONB_ARRAY_ELEMENTS(pgroonga_command('table_list')::jsonb->1) tmp
 ) table_list
 WHERE name = '"#{table_name}"';

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -186,7 +186,7 @@ INSERT INTO memos
     setup :require_pgroonga_benchmark
 
     setup def omit_on_ci
-      if ENV["CI"]
+      if ENV["CI"] == "true"
         omit("This test may take 2-60 min.") if data[:crash_ratio] > 0.1
       end
     end


### PR DESCRIPTION
Time-expensive tests are skipped on CI, but this may delay noticing failures.
Change to run all tests once a day.
It usually takes about 2 hours, so we set a timeout of 150 minutes.