### PR TITLE
regexp-v2: add support for &~ operator (targets text[], pattern text)

### DIFF
--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -1958,6 +1958,24 @@ CREATE OPERATOR &~ (
 	JOIN = contjoinsel
 );
 
+CREATE FUNCTION pgroonga_regexp_text_array(targets text[], pattern text)
+	RETURNS bool
+	AS 'MODULE_PATHNAME', 'pgroonga_regexp_text_array'
+	LANGUAGE C
+	IMMUTABLE
+	STRICT
+	LEAKPROOF
+	PARALLEL SAFE
+	COST 300;
+
+CREATE OPERATOR &~ (
+	PROCEDURE = pgroonga_regexp_text_array,
+	LEFTARG = text[],
+	RIGHTARG = text,
+	RESTRICT = contsel,
+	JOIN = contjoinsel
+);
+
 CREATE FUNCTION pgroonga_regexp_varchar(varchar, varchar)
 	RETURNS bool
 	AS 'MODULE_PATHNAME', 'pgroonga_regexp_varchar'
@@ -2499,6 +2517,10 @@ CREATE OPERATOR CLASS pgroonga_text_regexp_ops_v2 FOR TYPE text
 		OPERATOR 10 @~, -- For backward compatibility
 		OPERATOR 22 &~,
 		OPERATOR 35 &~| (text, text[]);
+
+CREATE OPERATOR CLASS pgroonga_text_array_regexp_ops_v2 FOR TYPE text[]
+	USING pgroonga AS
+		OPERATOR 22 &~ (text[], text);
 
 CREATE OPERATOR CLASS pgroonga_varchar_term_search_ops_v2
 	DEFAULT FOR TYPE varchar

--- a/expected/regexp/text-array/regexp-v2/begin-of-text/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/begin-of-text/bitmapscan.out
@@ -1,0 +1,38 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+                     QUERY PLAN                     
+----------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (content &~ '\Agroonga'::text)
+   ->  Bitmap Index Scan on pgrn_content_index
+         Index Cond: (content &~ '\Agroonga'::text)
+(4 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+ id |                                                          content                                                           
+----+----------------------------------------------------------------------------------------------------------------------------
+  1 | {"PostgreSQL is a RDBMS","Groonga is fast full text search engine","PGroonga is a PostgreSQL extension that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/begin-of-text/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/begin-of-text/indexscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+                  QUERY PLAN                  
+----------------------------------------------
+ Index Scan using pgrn_content_index on memos
+   Index Cond: (content &~ '\Agroonga'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+ id |                                                          content                                                           
+----+----------------------------------------------------------------------------------------------------------------------------
+  1 | {"PostgreSQL is a RDBMS","Groonga is fast full text search engine","PGroonga is a PostgreSQL extension that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/begin-of-text/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/begin-of-text/seqscan.out
@@ -1,0 +1,35 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+                QUERY PLAN                
+------------------------------------------
+ Seq Scan on memos
+   Filter: (content &~ '\Agroonga'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/dot/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/dot/bitmapscan.out
@@ -1,0 +1,38 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+                    QUERY PLAN                    
+--------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (content &~ '.torage'::text)
+   ->  Bitmap Index Scan on pgrn_content_index
+         Index Cond: (content &~ '.torage'::text)
+(4 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+ id |                                  content                                   
+----+----------------------------------------------------------------------------
+  2 | {"MySQL is a RDBMS","Mroonga is a MySQL storage engine that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/dot/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/dot/indexscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+                  QUERY PLAN                  
+----------------------------------------------
+ Index Scan using pgrn_content_index on memos
+   Index Cond: (content &~ '.torage'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+ id |                                  content                                   
+----+----------------------------------------------------------------------------
+  2 | {"MySQL is a RDBMS","Mroonga is a MySQL storage engine that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/dot/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/dot/seqscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+               QUERY PLAN               
+----------------------------------------
+ Seq Scan on memos
+   Filter: (content &~ '.torage'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+ id |                                  content                                   
+----+----------------------------------------------------------------------------
+  2 | {"MySQL is a RDBMS","Mroonga is a MySQL storage engine that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/end-of-text/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/end-of-text/bitmapscan.out
@@ -1,0 +1,38 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+                    QUERY PLAN                     
+---------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (content &~ 'engine\z'::text)
+   ->  Bitmap Index Scan on pgrn_content_index
+         Index Cond: (content &~ 'engine\z'::text)
+(4 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+ id |                                                          content                                                           
+----+----------------------------------------------------------------------------------------------------------------------------
+  1 | {"PostgreSQL is a RDBMS","Groonga is fast full text search engine","PGroonga is a PostgreSQL extension that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/end-of-text/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/end-of-text/indexscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+                  QUERY PLAN                  
+----------------------------------------------
+ Index Scan using pgrn_content_index on memos
+   Index Cond: (content &~ 'engine\z'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+ id |                                                          content                                                           
+----+----------------------------------------------------------------------------------------------------------------------------
+  1 | {"PostgreSQL is a RDBMS","Groonga is fast full text search engine","PGroonga is a PostgreSQL extension that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/end-of-text/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/end-of-text/seqscan.out
@@ -1,0 +1,35 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+               QUERY PLAN                
+-----------------------------------------
+ Seq Scan on memos
+   Filter: (content &~ 'engine\z'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/exact/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/exact/bitmapscan.out
@@ -1,0 +1,38 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL',
+                      'Groonga',
+                      'PGroonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL',
+                      'Mroonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+                      QUERY PLAN                      
+------------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (content &~ '\Agroonga\z'::text)
+   ->  Bitmap Index Scan on pgrn_content_index
+         Index Cond: (content &~ '\Agroonga\z'::text)
+(4 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+ id |            content            
+----+-------------------------------
+  1 | {PostgreSQL,Groonga,PGroonga}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/exact/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/exact/indexscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL',
+                      'Groonga',
+                      'PGroonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL',
+                      'Mroonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+                   QUERY PLAN                   
+------------------------------------------------
+ Index Scan using pgrn_content_index on memos
+   Index Cond: (content &~ '\Agroonga\z'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+ id |            content            
+----+-------------------------------
+  1 | {PostgreSQL,Groonga,PGroonga}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/exact/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/exact/seqscan.out
@@ -1,0 +1,35 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL',
+                      'Groonga',
+                      'PGroonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL',
+                      'Mroonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+                 QUERY PLAN                 
+--------------------------------------------
+ Seq Scan on memos
+   Filter: (content &~ '\Agroonga\z'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+ id | content 
+----+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/partial/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/partial/bitmapscan.out
@@ -1,0 +1,38 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+                    QUERY PLAN                    
+--------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (content &~ 'storage'::text)
+   ->  Bitmap Index Scan on pgrn_content_index
+         Index Cond: (content &~ 'storage'::text)
+(4 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+ id |                                  content                                   
+----+----------------------------------------------------------------------------
+  2 | {"MySQL is a RDBMS","Mroonga is a MySQL storage engine that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/partial/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/partial/indexscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+                  QUERY PLAN                  
+----------------------------------------------
+ Index Scan using pgrn_content_index on memos
+   Index Cond: (content &~ 'storage'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+ id |                                  content                                   
+----+----------------------------------------------------------------------------
+  2 | {"MySQL is a RDBMS","Mroonga is a MySQL storage engine that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/partial/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/partial/seqscan.out
@@ -1,0 +1,36 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+               QUERY PLAN               
+----------------------------------------
+ Seq Scan on memos
+   Filter: (content &~ 'storage'::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+ id |                                  content                                   
+----+----------------------------------------------------------------------------
+  2 | {"MySQL is a RDBMS","Mroonga is a MySQL storage engine that uses Groonga"}
+(1 row)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/row-level-security/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/row-level-security/bitmapscan.out
@@ -1,0 +1,48 @@
+CREATE TABLE memos (
+  id integer,
+  user_name text,
+  content text[]
+);
+CREATE USER alice NOLOGIN;
+GRANT ALL ON TABLE memos TO alice;
+INSERT INTO memos VALUES
+  (1, 'nonexistent', ARRAY['PostgreSQL is a RDBMS.',
+                           'MySQL is a RDBMS',
+                           'MariaDB is a RDBMS']);
+INSERT INTO memos VALUES
+  (2, 'alice', ARRAY['Groonga is fast full text search engine.',
+                     'PGroonga is a PostgreSQL extension that uses Groonga.',
+                     'Mroonga is a MySQL storage engine that uses Groonga.']);
+ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memos_myself ON memos USING (user_name = current_user);
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+SET SESSION AUTHORIZATION alice;
+\pset format unaligned
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga'
+\g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
+QUERY PLAN
+Bitmap Heap Scan on memos
+  Recheck Cond: (content &~ 'pgroonga'::text)
+  Filter: (user_name = CURRENT_USER)
+  ->  Bitmap Index Scan on pgrn_index
+        Index Cond: (content &~ 'pgroonga'::text)
+(5 rows)
+\pset format aligned
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga';
+ id |                                                                           content                                                                           
+----+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"Groonga is fast full text search engine.","PGroonga is a PostgreSQL extension that uses Groonga.","Mroonga is a MySQL storage engine that uses Groonga."}
+(1 row)
+
+RESET SESSION AUTHORIZATION;
+DROP TABLE memos;
+DROP USER alice;

--- a/expected/regexp/text-array/regexp-v2/row-level-security/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/row-level-security/indexscan.out
@@ -1,0 +1,46 @@
+CREATE TABLE memos (
+  id integer,
+  user_name text,
+  content text[]
+);
+CREATE USER alice NOLOGIN;
+GRANT ALL ON TABLE memos TO alice;
+INSERT INTO memos VALUES
+  (1, 'nonexistent', ARRAY['PostgreSQL is a RDBMS.',
+                           'MySQL is a RDBMS',
+                           'MariaDB is a RDBMS']);
+INSERT INTO memos VALUES
+  (2, 'alice', ARRAY['Groonga is fast full text search engine.',
+                     'PGroonga is a PostgreSQL extension that uses Groonga.',
+                     'Mroonga is a MySQL storage engine that uses Groonga.']);
+ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memos_myself ON memos USING (user_name = current_user);
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+SET SESSION AUTHORIZATION alice;
+\pset format unaligned
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga'
+\g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
+QUERY PLAN
+Index Scan using pgrn_index on memos
+  Index Cond: (content &~ 'pgroonga'::text)
+  Filter: (user_name = CURRENT_USER)
+(3 rows)
+\pset format aligned
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga';
+ id |                                                                           content                                                                           
+----+-------------------------------------------------------------------------------------------------------------------------------------------------------------
+  2 | {"Groonga is fast full text search engine.","PGroonga is a PostgreSQL extension that uses Groonga.","Mroonga is a MySQL storage engine that uses Groonga."}
+(1 row)
+
+RESET SESSION AUTHORIZATION;
+DROP TABLE memos;
+DROP USER alice;

--- a/expected/regexp/text-array/regexp-v2/row-level-security/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/row-level-security/seqscan.out
@@ -1,0 +1,44 @@
+CREATE TABLE memos (
+  id integer,
+  user_name text,
+  content text[]
+);
+CREATE USER alice NOLOGIN;
+GRANT ALL ON TABLE memos TO alice;
+INSERT INTO memos VALUES
+  (1, 'nonexistent', ARRAY['PostgreSQL is a RDBMS.',
+                           'MySQL is a RDBMS.',
+                           'MariaDB is a RDBMS.']);
+INSERT INTO memos VALUES
+  (2, 'alice', ARRAY['Groonga is fast full text search engine.',
+                     'PGroonga is a PostgreSQL extension that uses Groonga.',
+                     'Mroonga is a MySQL storage engine that uses Groonga.']);
+ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memos_myself ON memos USING (user_name = current_user);
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SET SESSION AUTHORIZATION alice;
+\pset format unaligned
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga'
+\g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
+QUERY PLAN
+Seq Scan on memos
+  Filter: ((user_name = CURRENT_USER) AND (content &~ 'pgroonga'::text))
+(2 rows)
+\pset format aligned
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga';
+ id | content 
+----+---------
+(0 rows)
+
+RESET SESSION AUTHORIZATION;
+DROP TABLE memos;
+DROP USER alice;

--- a/sql/regexp/text-array/regexp-v2/begin-of-text/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/begin-of-text/bitmapscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/begin-of-text/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/begin-of-text/indexscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/begin-of-text/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/begin-of-text/seqscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/dot/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/dot/bitmapscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/dot/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/dot/indexscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/dot/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/dot/seqscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '.torage';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/end-of-text/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/end-of-text/bitmapscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/end-of-text/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/end-of-text/indexscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/end-of-text/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/end-of-text/seqscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'engine\z';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/exact/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/exact/bitmapscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL',
+                      'Groonga',
+                      'PGroonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL',
+                      'Mroonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/exact/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/exact/indexscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL',
+                      'Groonga',
+                      'PGroonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL',
+                      'Mroonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/exact/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/exact/seqscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL',
+                      'Groonga',
+                      'PGroonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL',
+                      'Mroonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '\Agroonga\z';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/partial/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/partial/bitmapscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/partial/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/partial/indexscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/partial/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/partial/seqscan.sql
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer,
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (1, ARRAY['PostgreSQL is a RDBMS',
+                      'Groonga is fast full text search engine',
+                      'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (2, ARRAY['MySQL is a RDBMS',
+                      'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+
+SELECT *
+  FROM memos
+ WHERE content &~ 'storage';
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/row-level-security/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/row-level-security/bitmapscan.sql
@@ -1,0 +1,45 @@
+CREATE TABLE memos (
+  id integer,
+  user_name text,
+  content text[]
+);
+
+CREATE USER alice NOLOGIN;
+GRANT ALL ON TABLE memos TO alice;
+
+INSERT INTO memos VALUES
+  (1, 'nonexistent', ARRAY['PostgreSQL is a RDBMS.',
+                           'MySQL is a RDBMS',
+                           'MariaDB is a RDBMS']);
+INSERT INTO memos VALUES
+  (2, 'alice', ARRAY['Groonga is fast full text search engine.',
+                     'PGroonga is a PostgreSQL extension that uses Groonga.',
+                     'Mroonga is a MySQL storage engine that uses Groonga.']);
+
+ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memos_myself ON memos USING (user_name = current_user);
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+SET SESSION AUTHORIZATION alice;
+\pset format unaligned
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga'
+\g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
+\pset format aligned
+
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga';
+RESET SESSION AUTHORIZATION;
+
+DROP TABLE memos;
+
+DROP USER alice;

--- a/sql/regexp/text-array/regexp-v2/row-level-security/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/row-level-security/indexscan.sql
@@ -1,0 +1,45 @@
+CREATE TABLE memos (
+  id integer,
+  user_name text,
+  content text[]
+);
+
+CREATE USER alice NOLOGIN;
+GRANT ALL ON TABLE memos TO alice;
+
+INSERT INTO memos VALUES
+  (1, 'nonexistent', ARRAY['PostgreSQL is a RDBMS.',
+                           'MySQL is a RDBMS',
+                           'MariaDB is a RDBMS']);
+INSERT INTO memos VALUES
+  (2, 'alice', ARRAY['Groonga is fast full text search engine.',
+                     'PGroonga is a PostgreSQL extension that uses Groonga.',
+                     'Mroonga is a MySQL storage engine that uses Groonga.']);
+
+ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memos_myself ON memos USING (user_name = current_user);
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+SET SESSION AUTHORIZATION alice;
+\pset format unaligned
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga'
+\g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
+\pset format aligned
+
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga';
+RESET SESSION AUTHORIZATION;
+
+DROP TABLE memos;
+
+DROP USER alice;

--- a/sql/regexp/text-array/regexp-v2/row-level-security/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/row-level-security/seqscan.sql
@@ -1,0 +1,45 @@
+CREATE TABLE memos (
+  id integer,
+  user_name text,
+  content text[]
+);
+
+CREATE USER alice NOLOGIN;
+GRANT ALL ON TABLE memos TO alice;
+
+INSERT INTO memos VALUES
+  (1, 'nonexistent', ARRAY['PostgreSQL is a RDBMS.',
+                           'MySQL is a RDBMS.',
+                           'MariaDB is a RDBMS.']);
+INSERT INTO memos VALUES
+  (2, 'alice', ARRAY['Groonga is fast full text search engine.',
+                     'PGroonga is a PostgreSQL extension that uses Groonga.',
+                     'Mroonga is a MySQL storage engine that uses Groonga.']);
+
+ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
+CREATE POLICY memos_myself ON memos USING (user_name = current_user);
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+SET SESSION AUTHORIZATION alice;
+\pset format unaligned
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga'
+\g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
+\pset format aligned
+
+SELECT id, content
+  FROM memos
+ WHERE content &~ 'pgroonga';
+RESET SESSION AUTHORIZATION;
+
+DROP TABLE memos;
+
+DROP USER alice;


### PR DESCRIPTION
GitHub: GH-570
This is a part of the task of adding support for `pgroonga_text_array_regexp_ops_v2`.

TODO:
Add more tests.
Write more commit log.