### PR TITLE
regexp-v2: add a test for empty pattern with seqscan

### DIFF
--- a/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
@@ -5,9 +5,6 @@ INSERT INTO memos
      VALUES (ARRAY['PostgreSQL is a RDBMS',
                    'Groonga is fast full text search engine',
                    'PGroonga is a PostgreSQL extension that uses Groonga']);
-SET enable_seqscan = on;
-SET enable_indexscan = off;
-SET enable_bitmapscan = off;
 EXPLAIN (COSTS OFF)
 SELECT *
   FROM memos

--- a/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
@@ -1,5 +1,5 @@
 CREATE TABLE memos (
-  content text[]
+  contents text[]
 );
 INSERT INTO memos
      VALUES (ARRAY['PostgreSQL is a RDBMS',
@@ -8,18 +8,18 @@ INSERT INTO memos
 EXPLAIN (COSTS OFF)
 SELECT *
   FROM memos
- WHERE content &~ '';
-           QUERY PLAN            
----------------------------------
+ WHERE contents &~ '';
+            QUERY PLAN            
+----------------------------------
  Seq Scan on memos
-   Filter: (content &~ ''::text)
+   Filter: (contents &~ ''::text)
 (2 rows)
 
 SELECT *
   FROM memos
- WHERE content &~ '';
- content 
----------
+ WHERE contents &~ '';
+ contents 
+----------
 (0 rows)
 
 DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
@@ -1,0 +1,31 @@
+CREATE TABLE memos (
+  content text[]
+);
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '';
+           QUERY PLAN            
+---------------------------------
+ Seq Scan on memos
+   Filter: (content &~ ''::text)
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ '';
+ content 
+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/empty-string/seqscan.out
@@ -5,9 +5,6 @@ INSERT INTO memos
      VALUES (ARRAY['PostgreSQL is a RDBMS',
                    'Groonga is fast full text search engine',
                    'PGroonga is a PostgreSQL extension that uses Groonga']);
-CREATE INDEX pgrn_content_index
-    ON memos
- USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;

--- a/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
@@ -7,10 +7,6 @@ INSERT INTO memos
                    'Groonga is fast full text search engine',
                    'PGroonga is a PostgreSQL extension that uses Groonga']);
 
-SET enable_seqscan = on;
-SET enable_indexscan = off;
-SET enable_bitmapscan = off;
-
 EXPLAIN (COSTS OFF)
 SELECT *
   FROM memos

--- a/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
@@ -7,10 +7,6 @@ INSERT INTO memos
                    'Groonga is fast full text search engine',
                    'PGroonga is a PostgreSQL extension that uses Groonga']);
 
-CREATE INDEX pgrn_content_index
-    ON memos
- USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
-
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;

--- a/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
@@ -1,5 +1,5 @@
 CREATE TABLE memos (
-  content text[]
+  contents text[]
 );
 
 INSERT INTO memos
@@ -10,10 +10,10 @@ INSERT INTO memos
 EXPLAIN (COSTS OFF)
 SELECT *
   FROM memos
- WHERE content &~ '';
+ WHERE contents &~ '';
 
 SELECT *
   FROM memos
- WHERE content &~ '';
+ WHERE contents &~ '';
 
 DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/empty-string/seqscan.sql
@@ -1,0 +1,27 @@
+CREATE TABLE memos (
+  content text[]
+);
+
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+CREATE INDEX pgrn_content_index
+    ON memos
+ USING pgroonga (content pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ '';
+
+SELECT *
+  FROM memos
+ WHERE content &~ '';
+
+DROP TABLE memos;

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -4209,6 +4209,12 @@ pgroonga_regexp_text(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(matched);
 }
 
+/**
+ * Caller must satisfy the following conditions:
+ * * targets is not empty
+ * * pattern is not NULL(TODO: We don't implement yet)
+ * * pattern is not an empty text
+ */
 static bool
 pgroonga_match_regexp_text_array_raw(ArrayType *targets, text *pattern)
 {
@@ -4219,8 +4225,6 @@ pgroonga_match_regexp_text_array_raw(ArrayType *targets, text *pattern)
 	bool isNULL;
 
 	if (ARR_NDIM(targets) == 0)
-		return false;
-	if (PGrnPGTextIsEmpty(pattern))
 		return false;
 
 	condition.query = pattern;
@@ -4257,6 +4261,9 @@ pgroonga_regexp_text_array(PG_FUNCTION_ARGS)
 	ArrayType *targets = PG_GETARG_ARRAYTYPE_P(0);
 	text *pattern = PG_GETARG_TEXT_PP(1);
 	bool matched = false;
+
+	if (PGrnPGTextIsEmpty(pattern))
+		return false;
 
 	PGRN_RLS_ENABLED_IF(PGrnCheckRLSEnabledSeqScan(fcinfo));
 	{

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -4209,12 +4209,6 @@ pgroonga_regexp_text(PG_FUNCTION_ARGS)
 	PG_RETURN_BOOL(matched);
 }
 
-/**
- * Caller must satisfy the following conditions:
- * * targets is not empty
- * * pattern is not NULL(TODO: We don't implement yet)
- * * pattern is not an empty text
- */
 static bool
 pgroonga_match_regexp_text_array_raw(ArrayType *targets, text *pattern)
 {
@@ -4225,6 +4219,8 @@ pgroonga_match_regexp_text_array_raw(ArrayType *targets, text *pattern)
 	bool isNULL;
 
 	if (ARR_NDIM(targets) == 0)
+		return false;
+	if (PGrnPGTextIsEmpty(pattern))
 		return false;
 
 	condition.query = pattern;
@@ -4261,9 +4257,6 @@ pgroonga_regexp_text_array(PG_FUNCTION_ARGS)
 	ArrayType *targets = PG_GETARG_ARRAYTYPE_P(0);
 	text *pattern = PG_GETARG_TEXT_PP(1);
 	bool matched = false;
-
-	if (PGrnPGTextIsEmpty(pattern))
-		return false;
 
 	PGRN_RLS_ENABLED_IF(PGrnCheckRLSEnabledSeqScan(fcinfo));
 	{


### PR DESCRIPTION
We can't add tests for indexscan and bitmapscan. Because they reject an empty pattern for now.
But we'll accept it in a separated PR. We'll add tests for them in the PR.