### PR TITLE
regexp-v2 text[]: add tests for NULL pattern

### DIFF
--- a/expected/regexp/text-array/regexp-v2/null/bitmapscan.out
+++ b/expected/regexp/text-array/regexp-v2/null/bitmapscan.out
@@ -1,0 +1,34 @@
+CREATE TABLE memos (
+  contents text[]
+);
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (ARRAY['MySQL is a RDBMS',
+                   'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_contents_index
+    ON memos
+ USING pgroonga (contents pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+ contents 
+----------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/null/indexscan.out
+++ b/expected/regexp/text-array/regexp-v2/null/indexscan.out
@@ -1,0 +1,34 @@
+CREATE TABLE memos (
+  contents text[]
+);
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (ARRAY['MySQL is a RDBMS',
+                   'Mroonga is a MySQL storage engine that uses Groonga']);
+CREATE INDEX pgrn_contents_index
+    ON memos
+ USING pgroonga (contents pgroonga_text_array_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+ contents 
+----------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/text-array/regexp-v2/null/seqscan.out
+++ b/expected/regexp/text-array/regexp-v2/null/seqscan.out
@@ -1,0 +1,31 @@
+CREATE TABLE memos (
+  contents text[]
+);
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+INSERT INTO memos
+     VALUES (ARRAY['MySQL is a RDBMS',
+                   'Mroonga is a MySQL storage engine that uses Groonga']);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+ contents 
+----------
+(0 rows)
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/null/bitmapscan.sql
+++ b/sql/regexp/text-array/regexp-v2/null/bitmapscan.sql
@@ -1,0 +1,31 @@
+CREATE TABLE memos (
+  contents text[]
+);
+
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (ARRAY['MySQL is a RDBMS',
+                   'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_contents_index
+    ON memos
+ USING pgroonga (contents pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/null/indexscan.sql
+++ b/sql/regexp/text-array/regexp-v2/null/indexscan.sql
@@ -1,0 +1,31 @@
+CREATE TABLE memos (
+  contents text[]
+);
+
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (ARRAY['MySQL is a RDBMS',
+                   'Mroonga is a MySQL storage engine that uses Groonga']);
+
+CREATE INDEX pgrn_contents_index
+    ON memos
+ USING pgroonga (contents pgroonga_text_array_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+
+DROP TABLE memos;

--- a/sql/regexp/text-array/regexp-v2/null/seqscan.sql
+++ b/sql/regexp/text-array/regexp-v2/null/seqscan.sql
@@ -1,0 +1,27 @@
+CREATE TABLE memos (
+  contents text[]
+);
+
+INSERT INTO memos
+     VALUES (ARRAY['PostgreSQL is a RDBMS',
+                   'Groonga is fast full text search engine',
+                   'PGroonga is a PostgreSQL extension that uses Groonga']);
+
+INSERT INTO memos
+     VALUES (ARRAY['MySQL is a RDBMS',
+                   'Mroonga is a MySQL storage engine that uses Groonga']);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+
+SELECT *
+  FROM memos
+ WHERE contents &~ NULL;
+
+DROP TABLE memos;


### PR DESCRIPTION
`&~(text[], text)` specifies `STRICT`.
So, `&~ NULL` always returns `NULL`.