### PR TITLE
regexp-v2 varchar: add tests for NULL pattern

### DIFF
--- a/expected/regexp/varchar/regexp-v2/null/bitmapscan.out
+++ b/expected/regexp/varchar/regexp-v2/null/bitmapscan.out
@@ -1,0 +1,29 @@
+CREATE TABLE memos (
+  content varchar(256)
+);
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga');
+CREATE INDEX pgrn_content_index ON memos
+ USING pgroonga (content pgroonga_varchar_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+ content 
+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/varchar/regexp-v2/null/indexscan.out
+++ b/expected/regexp/varchar/regexp-v2/null/indexscan.out
@@ -1,0 +1,29 @@
+CREATE TABLE memos (
+  content varchar(256)
+);
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga');
+CREATE INDEX pgrn_content_index ON memos
+ USING pgroonga (content pgroonga_varchar_regexp_ops_v2);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+ content 
+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/expected/regexp/varchar/regexp-v2/null/seqscan.out
+++ b/expected/regexp/varchar/regexp-v2/null/seqscan.out
@@ -1,0 +1,27 @@
+CREATE TABLE memos (
+  content varchar(256)
+);
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga');
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+        QUERY PLAN        
+--------------------------
+ Result
+   One-Time Filter: false
+(2 rows)
+
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+ content 
+---------
+(0 rows)
+
+DROP TABLE memos;

--- a/sql/regexp/varchar/regexp-v2/null/bitmapscan.sql
+++ b/sql/regexp/varchar/regexp-v2/null/bitmapscan.sql
@@ -1,0 +1,25 @@
+CREATE TABLE memos (
+  content varchar(256)
+);
+
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga');
+
+CREATE INDEX pgrn_content_index ON memos
+ USING pgroonga (content pgroonga_varchar_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+
+DROP TABLE memos;

--- a/sql/regexp/varchar/regexp-v2/null/indexscan.sql
+++ b/sql/regexp/varchar/regexp-v2/null/indexscan.sql
@@ -1,0 +1,25 @@
+CREATE TABLE memos (
+  content varchar(256)
+);
+
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga');
+
+CREATE INDEX pgrn_content_index ON memos
+ USING pgroonga (content pgroonga_varchar_regexp_ops_v2);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+
+DROP TABLE memos;

--- a/sql/regexp/varchar/regexp-v2/null/seqscan.sql
+++ b/sql/regexp/varchar/regexp-v2/null/seqscan.sql
@@ -1,0 +1,22 @@
+CREATE TABLE memos (
+  content varchar(256)
+);
+
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga');
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+
+SELECT *
+  FROM memos
+ WHERE content &~ NULL;
+
+DROP TABLE memos;


### PR DESCRIPTION
`&~(varchar, text)` specifies `STRICT`.
So, `&~ NULL` always returns `NULL`.