### PR TITLE
regexp-v2 varchar: check NULL and empty as faster as possible with sequential search

### DIFF
--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -4320,6 +4320,9 @@ pgroonga_regexp_varchar(PG_FUNCTION_ARGS)
 	PGrnCondition condition = {0};
 	bool matched = false;
 
+	if (PGrnPGTextIsEmpty(pattern))
+		return false;
+
 	condition.query = pattern;
 	PGRN_RLS_ENABLED_IF(PGrnCheckRLSEnabledSeqScan(fcinfo));
 	{


### PR DESCRIPTION
GitHub: GH-599

Tests for this case are the following directories.

* sql/regexp/varchar/regexp-v2/null/
* sql/regexp/varchar/regexp-v2/empty/