### PR TITLE
regexp-v2 text: check NULL and empty as faster as possible with sequential search

### DIFF
--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -4201,6 +4201,9 @@ pgroonga_regexp_text(PG_FUNCTION_ARGS)
 	PGrnCondition condition = {0};
 	bool matched = false;
 
+	if (PGrnPGTextIsEmpty(pattern))
+		return false;
+
 	condition.query = pattern;
 	PGRN_RLS_ENABLED_IF(PGrnCheckRLSEnabledSeqScan(fcinfo));
 	{


### PR DESCRIPTION
GitHub: GH-599

Tests for this case exist in the following directories:

* sql/regexp/text/regexp-v2/null/
* sql/regexp/text/regexp-v2/empty/