### PR TITLE
pgrn-compatible: remove PGRN_INDEX_AM_ROUTINE_HAVE_AM_PARALLEL_VACUUM_OPTIONS

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -29,10 +29,6 @@
 #	define PGRN_AM_INSERT_HAVE_INDEX_UNCHANGED
 #endif
 
-#if PG_VERSION_NUM >= 130000
-#	define PGRN_INDEX_AM_ROUTINE_HAVE_AM_PARALLEL_VACUUM_OPTIONS
-#endif
-
 #if PG_VERSION_NUM >= 160000
 #	define PGRN_RELATION_GET_LOCATOR(relation) ((relation)->rd_locator)
 #	define PGRN_RELATION_GET_LOCATOR_NUMBER(relation)                         \

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -46,9 +46,7 @@
 #include <catalog/index.h>
 #include <catalog/pg_type.h>
 #include <commands/progress.h>
-#ifdef PGRN_INDEX_AM_ROUTINE_HAVE_AM_PARALLEL_VACUUM_OPTIONS
-#	include <commands/vacuum.h>
-#endif
+#include <commands/vacuum.h>
 #include <mb/pg_wchar.h>
 #include <miscadmin.h>
 #include <nodes/nodeFuncs.h>
@@ -8425,9 +8423,7 @@ pgroonga_handler(PG_FUNCTION_ARGS)
 	routine->amcanparallel = true;
 	routine->amcaninclude = true;
 	routine->amusemaintenanceworkmem = false;
-#ifdef PGRN_INDEX_AM_ROUTINE_HAVE_AM_PARALLEL_VACUUM_OPTIONS
 	routine->amparallelvacuumoptions = VACUUM_OPTION_PARALLEL_BULKDEL;
-#endif
 	routine->amkeytype = InvalidOid;
 
 	routine->aminsert = pgroonga_insert;


### PR DESCRIPTION
GitHub: GH-607

We dropped support for PostgreSQL 12.
We can always use `commands/vaccum.h` and also use am parallel vacuum option for index am route. 