### PR TITLE
package apt test: drop support for under PostgreSQL 12

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -139,13 +139,6 @@ cp -a \
    /host/expected \
    /tmp/
 cd /tmp
-if [ ${postgresql_version} -lt 12 ]; then
-  rm sql/function/highlight-html/declarative-partitioning.sql
-  rm sql/function/wal-set-applied-position/declarative-partitioning.sql
-fi
-if [ ${postgresql_version} -lt 13 ]; then
-  rm sql/full-text-search/text/single/declarative-partitioning.sql
-fi
 ruby /host/test/prepare.rb > schedule
 PG_REGRESS_DIFF_OPTS="-u"
 if diff --help | grep -q color; then


### PR DESCRIPTION
GitHub: GH-607

We dropped support for PostgreSQL 12.
We no longer need any prior preparation for testing packages.