### PR TITLE
 test query-expand: drop support for PostgreSQL 12

### DIFF
--- a/expected/function/query-expand/multiple-terms.out
+++ b/expected/function/query-expand/multiple-terms.out
@@ -3,23 +3,10 @@ CREATE TABLE synonyms (
   synonyms text[]
 );
 CREATE INDEX synonyms_term_index ON synonyms (term);
-DO LANGUAGE plpgsql $$
-BEGIN
-	PERFORM 1
-		WHERE current_setting('server_version_num')::int >= 120000;
-	IF FOUND THEN
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Groonga', 'Senna']);
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Mroonga', 'PGroonga', 'Rroonga']);
-	ELSE
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Mroonga', 'PGroonga', 'Rroonga']);
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Groonga', 'Senna']);
-	END IF;
-END;
-$$;
+INSERT INTO synonyms
+	VALUES ('Groonga', ARRAY['Groonga', 'Senna']);
+INSERT INTO synonyms
+	VALUES ('Groonga', ARRAY['Mroonga', 'PGroonga', 'Rroonga']);
 SELECT pgroonga_query_expand('synonyms', 'term', 'synonyms', 'Groonga');
                      pgroonga_query_expand                      
 ----------------------------------------------------------------

--- a/expected/function/query-expand/text.out
+++ b/expected/function/query-expand/text.out
@@ -3,19 +3,8 @@ CREATE TABLE synonyms (
   synonym text
 );
 CREATE INDEX synonyms_term_index ON synonyms (term);
-DO LANGUAGE plpgsql $$
-BEGIN
-	PERFORM 1
-		WHERE current_setting('server_version_num')::int >= 120000;
-	IF FOUND THEN
-		INSERT INTO synonyms VALUES ('PGroonga', 'PGroonga');
-		INSERT INTO synonyms VALUES ('PGroonga', 'Groonga PostgreSQL');
-	ELSE
-		INSERT INTO synonyms VALUES ('PGroonga', 'Groonga PostgreSQL');
-		INSERT INTO synonyms VALUES ('PGroonga', 'PGroonga');
-	END IF;
-END;
-$$;
+INSERT INTO synonyms VALUES ('PGroonga', 'PGroonga');
+INSERT INTO synonyms VALUES ('PGroonga', 'Groonga PostgreSQL');
 SELECT pgroonga_query_expand('synonyms', 'term', 'synonym', 'PGroonga');
         pgroonga_query_expand         
 --------------------------------------

--- a/sql/function/query-expand/multiple-terms.sql
+++ b/sql/function/query-expand/multiple-terms.sql
@@ -5,23 +5,10 @@ CREATE TABLE synonyms (
 
 CREATE INDEX synonyms_term_index ON synonyms (term);
 
-DO LANGUAGE plpgsql $$
-BEGIN
-	PERFORM 1
-		WHERE current_setting('server_version_num')::int >= 120000;
-	IF FOUND THEN
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Groonga', 'Senna']);
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Mroonga', 'PGroonga', 'Rroonga']);
-	ELSE
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Mroonga', 'PGroonga', 'Rroonga']);
-		INSERT INTO synonyms
-			VALUES ('Groonga', ARRAY['Groonga', 'Senna']);
-	END IF;
-END;
-$$;
+INSERT INTO synonyms
+	VALUES ('Groonga', ARRAY['Groonga', 'Senna']);
+INSERT INTO synonyms
+	VALUES ('Groonga', ARRAY['Mroonga', 'PGroonga', 'Rroonga']);
 
 SELECT pgroonga_query_expand('synonyms', 'term', 'synonyms', 'Groonga');
 

--- a/sql/function/query-expand/text.sql
+++ b/sql/function/query-expand/text.sql
@@ -5,19 +5,8 @@ CREATE TABLE synonyms (
 
 CREATE INDEX synonyms_term_index ON synonyms (term);
 
-DO LANGUAGE plpgsql $$
-BEGIN
-	PERFORM 1
-		WHERE current_setting('server_version_num')::int >= 120000;
-	IF FOUND THEN
-		INSERT INTO synonyms VALUES ('PGroonga', 'PGroonga');
-		INSERT INTO synonyms VALUES ('PGroonga', 'Groonga PostgreSQL');
-	ELSE
-		INSERT INTO synonyms VALUES ('PGroonga', 'Groonga PostgreSQL');
-		INSERT INTO synonyms VALUES ('PGroonga', 'PGroonga');
-	END IF;
-END;
-$$;
+INSERT INTO synonyms VALUES ('PGroonga', 'PGroonga');
+INSERT INTO synonyms VALUES ('PGroonga', 'Groonga PostgreSQL');
 
 SELECT pgroonga_query_expand('synonyms', 'term', 'synonym', 'PGroonga');
 


### PR DESCRIPTION
GitHub: GH-607

We dropped support for PostgreSQL 12.
So we don't have to consider the following case to use PostgreSQL 12.
- ref: https://github.com/pgroonga/pgroonga/commit/b5bba12cbbb3dbcbb3d5f2c50e434b48a43880b1