### PR TITLE
ci linux: drop support for PostgreSQL 12

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,9 +106,6 @@ jobs:
           sudo -u postgres -H psql -c "CREATE ROLE ${USER} SUPERUSER LOGIN;"
       - name: Run regression test
         run: |
-          if [ ${{ matrix.postgresql-version }} -lt 13 ]; then
-            rm sql/full-text-search/text/single/declarative-partitioning.sql
-          fi
           test/run-sql-test.sh
         env:
           HAVE_XXHASH: "1"


### PR DESCRIPTION
GitHub: GH-607

We dropped support for PostgreSQL 12.
We no longer need any prior preparation for regression tests.