### PR TITLE
ci macos: drop support for PostgreSQL 12

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,9 +81,6 @@ jobs:
             ${GITHUB_PATH}
       - name: Run regression test
         run: |
-          if [ ${{ matrix.postgresql-version }} -lt 13 ]; then
-            rm sql/full-text-search/text/single/declarative-partitioning.sql
-          fi
           # TODO: Remove me when groonga formula enables libstemmer
           rm sql/full-text-search/text/options/token-filters/custom.sql
           # TODO: Remove me when groonga formula is 13.1.1 or later


### PR DESCRIPTION
GitHub: GH-607

We dropped support for PostgreSQL 12.
We no longer need any prior preparation for regression tests.