### PR TITLE
ci windows: drop support for PostgreSQL 12

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -191,9 +191,6 @@ jobs:
           Remove-Item sql\full-text-search\text\options\token-filters\custom.sql
           # Reduce tests to reduce test time
           Remove-Item sql\compatibility -Recurse -Force
-          if (${{ matrix.postgresql-version-major }} -lt 13) {
-            Remove-Item sql\full-text-search\text\single\declarative-partitioning.sql
-          }
           ruby test\prepare.rb > schedule
           $Env:PG_REGRESS_DIFF_OPTS = "-u"
           if (${{ matrix.postgresql-version-major }} -ge 17) {


### PR DESCRIPTION
GitHub: GH-607

We dropped support for PostgreSQL 12.
We no longer need any prior preparation for regression tests.