### PR TITLE
ci macos: remove needless processes for old Groonga

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,11 +83,6 @@ jobs:
         run: |
           # TODO: Remove me when groonga formula enables libstemmer
           rm sql/full-text-search/text/options/token-filters/custom.sql
-          # TODO: Remove me when groonga formula is 13.1.1 or later
-          rm sql/term-search/varchar-array/prefix-condition/weights/bitmapscan.sql
-          rm sql/term-search/varchar-array/prefix-condition/weights/indexscan.sql
-          rm sql/term-search/text-array/prefix-condition/weights/bitmapscan.sql
-          rm sql/term-search/text-array/prefix-condition/weights/indexscan.sql
           PG_CONFIG=$(brew --prefix postgresql@${{ matrix.postgresql-version }})/bin/pg_config \
             test/run-sql-test.sh
         env:


### PR DESCRIPTION
Because the current groonga formula uses Groonga 14.1.0.
- https://formulae.brew.sh/formula/groonga