### PR TITLE
ci: remove redundant configurations

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,8 +2,6 @@ name: Linux
 on:
   push:
   pull_request:
-    branches:
-      - "*"
   schedule:
     # * UTC 16:30
     # * JST 01:30

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,8 +2,6 @@ name: macOS
 on:
   push:
   pull_request:
-    branches:
-      - "*"
   schedule:
     - cron: |
         0 0 * * *

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -2,8 +2,6 @@ name: Setup
 on:
   push:
   pull_request:
-    branches:
-      - "*"
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,8 +2,6 @@ name: Windows
 on:
   push:
   pull_request:
-    branches:
-      - "*"
   schedule:
     - cron: |
         0 0 * * *


### PR DESCRIPTION
We can omit `branches: "*"` to run CI for all PRs.