### PR TITLE
test: text/multiple: Add SQL file for sequential search of `%%` operator

### DIFF
--- a/sql/compatibility/schema/full-text-search/text/multiple/match/seqscan.sql
+++ b/sql/compatibility/schema/full-text-search/text/multiple/match/seqscan.sql
@@ -3,33 +3,28 @@ CREATE TABLE memos (
   title text,
   content text
 );
+
 INSERT INTO memos
      VALUES (1, 'PostgreSQL', 'is a RDBMS.');
 INSERT INTO memos
      VALUES (2, 'Groonga', 'is fast full text search engine.');
 INSERT INTO memos
      VALUES (3, 'PGroonga', 'is a PostgreSQL extension that uses Groonga.');
+
 CREATE INDEX grnindex ON memos
   USING pgroonga (title pgroonga.text_full_text_search_ops_v2,
                   content pgroonga.text_full_text_search_ops_v2);
+
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
+
 SELECT id, title, content
   FROM memos
  WHERE title %% 'Groonga';
- id |  title   |                   content                    
-----+----------+----------------------------------------------
-  2 | Groonga  | is fast full text search engine.
-  3 | PGroonga | is a PostgreSQL extension that uses Groonga.
-(2 rows)
 
 SELECT id, title, content
   FROM memos
  WHERE content %% 'Groonga';
- id |  title   |                   content                    
-----+----------+----------------------------------------------
-  3 | PGroonga | is a PostgreSQL extension that uses Groonga.
-(1 row)
 
 DROP TABLE memos;


### PR DESCRIPTION
Related: GitHub GH-637
Only the expected file existed, so add the SQL file.