### PR TITLE
pgroonga-crash-safer: specify namespace explicitly when calling `pgroonga_wal_set_applied_position()`

### DIFF
--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -157,14 +157,15 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 		int result;
 
 		SetCurrentStatementStartTimestamp();
-		result = SPI_execute(
-			"SELECT namespace.nspname AS schema_name "
-			"FROM pg_catalog.pg_proc AS proc "
-			"JOIN pg_catalog.pg_namespace AS namespace "
-			"  ON proc.pronamespace = namespace.oid "
-			"WHERE proc.proname = 'pgroonga_wal_set_applied_position'",
-			true,
-			0);
+		result =
+			SPI_execute("SELECT nspname AS schema_name"
+						"FROM pg_catalog.pg_namespace "
+						"WHERE oid in ( "
+						"  SELECT pronamespace "
+						"  FROM pg_catalog.pg_proc "
+						"  WHERE proname = 'pgroonga_wal_set_applied_position'",
+						true,
+						0);
 		if (result != SPI_OK_SELECT)
 		{
 			ereport(FATAL,

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -187,7 +187,7 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 			SetCurrentStatementStartTimestamp();
 			/**
 			 * The nspname column in pg_catalog.pg_namespace must not be NULL
-			 * because of Not NULL constraint.
+			 * because of NOT NULL constraint.
 			 */
 			schemaNameDatum = SPI_getbinval(
 				SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isNULL);

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -158,12 +158,13 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 
 		SetCurrentStatementStartTimestamp();
 		result = SPI_execute(
-			"SELECT nspname AS schema_name "
-			"FROM pg_catalog.pg_namespace "
-			"WHERE oid in ("
-			"  SELECT pronamespace "
-			"  FROM pg_catalog.pg_proc "
-			"  WHERE proname = 'pgroonga_wal_set_applied_position')",
+			"SELECT nspname "
+			"  FROM pg_catalog.pg_namespace "
+			"  WHERE oid in ("
+			"    SELECT pronamespace "
+			"    FROM pg_catalog.pg_proc "
+			"    WHERE proname = 'pgroonga_wal_set_applied_position'"
+			")",
 			true,
 			0);
 		if (result != SPI_OK_SELECT)

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -185,9 +185,17 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 			SetCurrentStatementStartTimestamp();
 			schemaNameDatum = SPI_getbinval(
 				SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isNull);
-			if (!isNull)
+			if (isNull)
 			{
-				// TODO: Write the error message
+				ereport(
+					FATAL,
+					(errmsg(PGRN_TAG
+							": failed to detect the schema which "
+							"pgroonga_wal_set_applied_position() is defined: "
+							"%u/%u: %d",
+							databaseOid,
+							tableSpaceOid,
+							result)));
 			}
 			else
 			{

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -191,14 +191,14 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 			}
 			else
 			{
-				StringInfo walSetAppliedPosition;
-				walSetAppliedPosition = makeStringInfo();
+				StringInfoData walSetAppliedPosition;
+				initStringInfo(&walSetAppliedPosition);
 				appendStringInfo(
-					walSetAppliedPosition,
+					&walSetAppliedPosition,
 					"SELECT %s.pgroonga_wal_set_applied_position()",
 					DatumGetCString(schemaNameDatum));
-				result = SPI_execute(walSetAppliedPosition->data, false, 0);
-				resetStringInfo(walSetAppliedPosition);
+				result = SPI_execute(walSetAppliedPosition.data, false, 0);
+				resetStringInfo(&walSetAppliedPosition);
 				if (result != SPI_OK_SELECT)
 				{
 					ereport(FATAL,

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -179,16 +179,16 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 		if (SPI_processed > 0)
 		{
 			char *schemaName;
-			StringInfo wal_set_applied_position;
+			StringInfo walSetAppliedPosition;
 
 			SetCurrentStatementStartTimestamp();
 			schemaName =
 				SPI_getvalue(SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1);
-			wal_set_applied_position = makeStringInfo();
-			appendStringInfo(wal_set_applied_position,
+			walSetAppliedPosition = makeStringInfo();
+			appendStringInfo(walSetAppliedPosition,
 							 "SELECT %s.pgroonga_wal_set_applied_position()",
 							 schemaName);
-			result = SPI_execute(wal_set_applied_position->data, false, 0);
+			result = SPI_execute(walSetAppliedPosition->data, false, 0);
 			if (result != SPI_OK_SELECT)
 			{
 				ereport(
@@ -200,7 +200,7 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 							tableSpaceOid,
 							result)));
 			}
-			resetStringInfo(wal_set_applied_position);
+			resetStringInfo(walSetAppliedPosition);
 			pfree(schemaName);
 		}
 	}

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -179,12 +179,17 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 
 		if (SPI_processed > 0)
 		{
+			bool isNULL;
 			Datum schemaNameDatum;
 			StringInfoData walSetAppliedPosition;
 
 			SetCurrentStatementStartTimestamp();
+			/**
+			 * The nspname column in pg_catalog.pg_namespace must not be NULL
+			 * because of Not NULL constraint.
+			 */
 			schemaNameDatum = SPI_getbinval(
-				SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, NULL);
+				SPI_tuptable->vals[0], SPI_tuptable->tupdesc, 1, &isNULL);
 			initStringInfo(&walSetAppliedPosition);
 			appendStringInfo(&walSetAppliedPosition,
 							 "SELECT %s.pgroonga_wal_set_applied_position()",

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -157,15 +157,15 @@ pgroonga_crash_safer_reset_position_one(Datum databaseInfoDatum)
 		int result;
 
 		SetCurrentStatementStartTimestamp();
-		result =
-			SPI_execute("SELECT nspname AS schema_name"
-						"FROM pg_catalog.pg_namespace "
-						"WHERE oid in ( "
-						"  SELECT pronamespace "
-						"  FROM pg_catalog.pg_proc "
-						"  WHERE proname = 'pgroonga_wal_set_applied_position'",
-						true,
-						0);
+		result = SPI_execute(
+			"SELECT nspname AS schema_name "
+			"FROM pg_catalog.pg_namespace "
+			"WHERE oid in ("
+			"  SELECT pronamespace "
+			"  FROM pg_catalog.pg_proc "
+			"  WHERE proname = 'pgroonga_wal_set_applied_position')",
+			true,
+			0);
 		if (result != SPI_OK_SELECT)
 		{
 			ereport(FATAL,

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -37,7 +37,7 @@ pgroonga_crash_safer.log_level = debug
                  run_sql(status_sql, may_wait_crash_safer_preparing: true))
   end
 
-  test "reset_wal_position_in_non_public_schema" do
+  test "reset positions in non public schema" do
     run_sql("DROP EXTENSION IF EXISTS pgroonga;")
     run_sql("CREATE SCHEMA test_schema;")
     run_sql("CREATE EXTENSION pgroonga WITH SCHEMA test_schema;")

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -97,29 +97,17 @@ SELECT * FROM memos WHERE content &@~ 'PGroonga';
     OUTPUT
   end
 
-  sub_test_case "use_custom_schema" do
-    test "recover pgroonga extension in custom schema from WAL" do
-      sql = <<-SQL
-DROP EXTENSION IF EXISTS pgroonga;
-CREATE SCHEMA test_schema;
-CREATE EXTENSION pgroonga WITH SCHEMA test_schema;
-SELECT pg_sleep(10);
-      SQL
-      run_sql(sql)
-      Dir.glob(File.join(@test_db_dir, "pgrn*")) do |path|
-        FileUtils.cp(path, "#{path}.bak")
-      end
-      stop_postgres
-      Dir.glob(File.join(@test_db_dir, "pgrn*.bak")) do |path|
-        FileUtils.cp(path, path.chomp(".bak"))
-      end
-      start_postgres
-      postgres_log = @postgresql.read_log
-      assert_not_equal(
-        ["ERROR:  function pgroonga_wal_set_applied_position() does not exist at character 8"],
-        postgres_log.scan(/ERROR:\s+function pgroonga_wal_set_applied_position\(\) does not exist at character \d+/),
-        postgres_log)
-    end
+  test "recover_pgroonga_extension_in_no_public_schema" do
+    run_sql("DROP EXTENSION IF EXISTS pgroonga;")
+    run_sql("CREATE SCHEMA test_schema;")
+    run_sql("CREATE EXTENSION pgroonga WITH SCHEMA test_schema;")
+    stop_postgres
+    start_postgres
+    postgres_log = @postgresql.read_log
+    assert_not_equal(
+      ["ERROR:  function pgroonga_wal_set_applied_position() does not exist at character 8"],
+      postgres_log.scan(/ERROR:\s+function pgroonga_wal_set_applied_position\(\) does not exist at character \d+/),
+      postgres_log)
   end
 
   test "recover by REINDEX" do

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -51,7 +51,7 @@ pgroonga_crash_safer.log_level = debug
     stop_postgres
     start_postgres
     assert_equal(status,
-      run_sql(status_sql, may_wait_crash_safer_preparing: true))
+                 run_sql(status_sql, may_wait_crash_safer_preparing: true))
   end
 
   sub_test_case "standby" do

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -38,7 +38,7 @@ pgroonga_crash_safer.log_level = debug
   end
 
   test "reset positions in non public schema" do
-    run_sql("DROP EXTENSION IF EXISTS pgroonga;")
+    run_sql("DROP EXTENSION pgroonga;")
     run_sql("CREATE SCHEMA test_schema;")
     run_sql("CREATE EXTENSION pgroonga WITH SCHEMA test_schema;")
     run_sql("CREATE TABLE test_schema.memos (title text);")

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -105,8 +105,8 @@ SELECT * FROM memos WHERE content &@~ 'PGroonga';
     start_postgres
     postgres_log = @postgresql.read_log
     assert_not_equal(
-      ["ERROR:  function pgroonga_wal_set_applied_position() does not exist at character 8"],
-      postgres_log.scan(/ERROR:\s+function pgroonga_wal_set_applied_position\(\) does not exist at character \d+/),
+      ["ERROR:  function pgroonga_wal_set_applied_position() does not exist"],
+      postgres_log.scan(/ERROR:\s+function pgroonga_wal_set_applied_position\(\) does not exist/),
       postgres_log)
   end
 

--- a/test/test-pgroonga-crash-safer.rb
+++ b/test/test-pgroonga-crash-safer.rb
@@ -37,6 +37,23 @@ pgroonga_crash_safer.log_level = debug
                  run_sql(status_sql, may_wait_crash_safer_preparing: true))
   end
 
+  test "reset_wal_position_in_non_public_schema" do
+    run_sql("DROP EXTENSION IF EXISTS pgroonga;")
+    run_sql("CREATE SCHEMA test_schema;")
+    run_sql("CREATE EXTENSION pgroonga WITH SCHEMA test_schema;")
+    run_sql("CREATE TABLE test_schema.memos (title text);")
+    run_sql("CREATE INDEX memos_title ON test_schema.memos USING pgroonga (title);")
+    run_sql("INSERT INTO test_schema.memos VALUES ('PGroonga');")
+    status_sql = "SELECT test_schema.pgroonga_wal_status();"
+    status = run_sql(status_sql)
+    run_sql("SELECT test_schema.pgroonga_wal_set_applied_position(100, 100);")
+    assert_not_equal(status, run_sql(status_sql))
+    stop_postgres
+    start_postgres
+    assert_equal(status,
+      run_sql(status_sql, may_wait_crash_safer_preparing: true))
+  end
+
   sub_test_case "standby" do
     setup :setup_standby_db
     teardown :teardown_standby_db
@@ -95,19 +112,6 @@ SELECT * FROM memos WHERE content &@~ 'PGroonga';
 (1 row)
 
     OUTPUT
-  end
-
-  test "recover_pgroonga_extension_in_no_public_schema" do
-    run_sql("DROP EXTENSION IF EXISTS pgroonga;")
-    run_sql("CREATE SCHEMA test_schema;")
-    run_sql("CREATE EXTENSION pgroonga WITH SCHEMA test_schema;")
-    stop_postgres
-    start_postgres
-    postgres_log = @postgresql.read_log
-    assert_not_equal(
-      ["ERROR:  function pgroonga_wal_set_applied_position() does not exist"],
-      postgres_log.scan(/ERROR:\s+function pgroonga_wal_set_applied_position\(\) does not exist/),
-      postgres_log)
   end
 
   test "recover by REINDEX" do


### PR DESCRIPTION
GitHub: fix GH-643

## Issue

`pgroonga_wal_set_applied_position()` was being called without a
schema name. If PGroonga was installed into a non-public schema,
the crash-safer background worker could not find
`pgroonga_wal_set_applied_position()` and raised an error.

## Cause

In `pgroonga_crash_safer_reset_position_one()`, the code executed
"SELECT pgroonga_wal_set_applied_position()" directly using
SPI_execute(). This relies on the search path including the correct
schema for the function. If PGroonga is installed into a custom
schema, the function call fails with "does not exist" because
search path does not include that schema.

## Solution

Look up the actual schema of `pgroonga_wal_set_applied_position()`
from `pg_proc` and `pg_namespace`, and then we explicitly
call it with custom schema in which PGroonga extension is defined.