### PR TITLE
ci release: create GitHub Release page and upload packages at once

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,38 +37,6 @@ jobs:
             pgroonga-*.tar.gz
             pgroonga-*.zip
 
-      # Release
-      - uses: actions/checkout@v4
-        if: |
-          startsWith(github.ref, 'refs/tags/')
-        with:
-          repository: "pgroonga/pgroonga.github.io"
-          path: "pgroonga.github.io"
-      - name: Extract release note
-        if: |
-          startsWith(github.ref, 'refs/tags/')
-        run: |
-          ruby \
-            -e 'print("## PGroonga "); \
-                puts(ARGF.read.split(/^## /)[1]. \
-                       gsub(/ {.+?}/, ""). \
-                       gsub(/\[(.+?)\]\[.+?\]/) {$1})' \
-            pgroonga.github.io/news/index.md > release-note.md
-      - name: Upload to release
-        if: |
-          startsWith(github.ref, 'refs/tags/')
-        run: |
-          title=$(head -n1 release-note.md | sed -e 's/^## //')
-          tail -n +2 release-note.md > release-note-without-version.md
-          gh release create ${GITHUB_REF_NAME} \
-            --discussion-category Releases \
-            --notes-file release-note-without-version.md \
-            --title "${title}" \
-            pgroonga-*.tar.gz \
-            pgroonga-*.zip
-        env:
-          GH_TOKEN: ${{ github.token }}
-
   linux:
     name: Linux
     needs: source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
       - name: Download artifacts
         run: |
           workflows=(package.yml windows.yml)
@@ -21,16 +20,19 @@ jobs:
                          --branch ${GITHUB_REF_NAME} \
                          --jq '.[].databaseId' \
                          --json databaseId \
+                         --repo ${GITHUB_REPOSITORY} \
                          --workflow ${workflow})
               sleep 1
             done
             gh run watch \
               --exit-status \
               --interval 60 \
+              --repo ${GITHUB_REPOSITORY} \
               ${run_id}
             gh run download ${run_id} \
               --dir release-artifacts \
-              --pattern "release-*"
+              --pattern "release-*" \
+              --repo ${GITHUB_REPOSITORY}
           done
         env:
           GH_TOKEN: ${{ github.token }}
@@ -53,6 +55,7 @@ jobs:
           gh release create ${GITHUB_REF_NAME} \
             --discussion-category Releases \
             --notes-file release-note-without-version.md \
+            --repo ${GITHUB_REPOSITORY} \
             --title "${title}" \
             release-artifacts/*/*
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           workflows=(package.yml windows.yml)
           for workflow in "${workflows[@]}"; do
             run_id=""
-            while [ -z "${run_id}" ]; do
+            while true; do
               echo "Waiting for run to start ${workflow}..."
               run_id=$(gh run list \
                          --branch ${GITHUB_REF_NAME} \
@@ -22,7 +22,10 @@ jobs:
                          --json databaseId \
                          --repo ${GITHUB_REPOSITORY} \
                          --workflow ${workflow})
-              sleep 1
+              if [ -n "${run_id}" ]; then
+                break
+              fi
+              sleep 60
             done
             gh run watch \
               --exit-status \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  github:
+    name: GitHub
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifacts
+        run: |
+          workflows=(package.yml windows.yml)
+          for workflow in "${workflows[@]}"; do
+            run_id=""
+            while [ -z "${run_id}" ]; do
+              echo "Waiting for run to start ${workflow}..."
+              run_id=$(gh run list \
+                         --branch ${GITHUB_REF_NAME} \
+                         --jq '.[].databaseId' \
+                         --json databaseId \
+                         --workflow ${workflow})
+              sleep 1
+            done
+            gh run watch \
+              --exit-status \
+              --interval 60 \
+              ${run_id}
+            gh run download ${run_id} \
+              --dir release-artifacts \
+              --pattern "release-*"
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: actions/checkout@v4
+        with:
+          repository: "pgroonga/pgroonga.github.io"
+          path: "pgroonga.github.io"
+      - name: Extract release note
+        run: |
+          ruby \
+            -e 'print("## PGroonga "); \
+                puts(ARGF.read.split(/^## /)[1]. \
+                       gsub(/ {.+?}/, ""). \
+                       gsub(/\[(.+?)\]\[.+?\]/) {$1})' \
+            pgroonga.github.io/news/index.md > release-note.md
+      - name: Publish
+        run: |
+          title=$(head -n1 release-note.md | sed -e 's/^## //')
+          tail -n +2 release-note.md > release-note-without-version.md
+          gh release create ${GITHUB_REF_NAME} \
+            --discussion-category Releases \
+            --notes-file release-note-without-version.md \
+            --title "${title}" \
+            release-artifacts/*/*
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
GitHub: close GH-649

This PR is a part of automatically releasing signed packages.

- [ ] Make release flow on CI. <- This PR is here.