### PR TITLE
pgroonga: remove pgroonga.bool_ops operator class

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -5,3 +5,4 @@ DROP OPERATOR FAMILY pgroonga.text_array_full_text_search_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_ops USING pgroonga;
+DROP OPERATOR FAMILY pgroonga.bool_ops USING pgroonga;

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -39,3 +39,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_array_ops FOR TYPE varchar[]
     USING pgroonga AS
         OPERATOR 8 %% (varchar[], varchar),
         OPERATOR 23 &> (varchar[], varchar);
+
+CREATE OPERATOR CLASS pgroonga.bool_ops FOR TYPE bool
+    USING pgroonga AS
+        OPERATOR 1 <,
+        OPERATOR 2 <=,
+        OPERATOR 3 =,
+        OPERATOR 4 >=,
+        OPERATOR 5 >;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -3133,14 +3133,6 @@ BEGIN
 			PARALLEL SAFE;
 
 		/* v1 */
-		CREATE OPERATOR CLASS pgroonga.bool_ops FOR TYPE bool
-			USING pgroonga AS
-				OPERATOR 1 <,
-				OPERATOR 2 <=,
-				OPERATOR 3 =,
-				OPERATOR 4 >=,
-				OPERATOR 5 >;
-
 		CREATE OPERATOR CLASS pgroonga.int2_ops FOR TYPE int2
 			USING pgroonga AS
 				OPERATOR 1 <,


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.


PGroonga's test don't remove in this PR.
Because `pgroonga.bool_ops` is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.bool_ops" ./*
./data/pgroonga--3.2.5.sql:		CREATE OPERATOR CLASS pgroonga.bool_ops FOR TYPE bool
./data/pgroonga--4.0.0--3.2.5.sql:CREATE OPERATOR CLASS pgroonga.bool_ops FOR TYPE bool
./data/pgroonga--3.2.5--4.0.0.sql:DROP OPERATOR FAMILY pgroonga.bool_ops USING pgroonga;
```

---

Result of upgrade test:

```
+ sudo dnf install -y /host/almalinux/9/x86_64/Packages/postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64.rpm
Last metadata expiration check: 0:00:19 ago on Mon Feb  3 03:26:20 2025.
Dependencies resolved.
=============================================================================================================================================================================
 Package                                              Architecture                     Version                                  Repository                              Size
=============================================================================================================================================================================
Upgrading:
 postgresql17-pgdg-pgroonga                           x86_64                           4.0.0-1.el9                              @commandline                           768 k

Transaction Summary
=============================================================================================================================================================================
Upgrade  1 Package

Total size: 768 k
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                     1/1 
  Upgrading        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       2/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       1/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       2/2 

Upgraded:
  postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                              

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE;'
ALTER EXTENSION pgroonga UPDATE;
ALTER EXTENSION
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE credentials
(
    id integer,
    name varchar,
    have_credential boolean
);
CREATE TABLE
INSERT INTO credentials
    (id, name, have_credential)
VALUES
    (1, 'Alice', true),
    (2, 'Bob', false);
INSERT 0 2
CREATE INDEX grnindex ON credentials
  USING pgroonga (have_credential pgroonga.bool_ops);
ERROR:  operator class "pgroonga.bool_ops" does not exist for access method "pgroonga"
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
EXPLAIN (COSTS OFF)
SELECT name
  FROM credentials
 WHERE have_credential = false;
           QUERY PLAN            
---------------------------------
 Seq Scan on credentials
   Filter: (NOT have_credential)
(2 rows)

SELECT name
  FROM credentials
 WHERE have_credential = false;
 name 
------
 Bob
(1 row)

DROP TABLE credentials;
DROP TABLE
```

Result of downgrade test:

```
+ sudo dnf install -y postgresql17-pgdg-pgroonga-debugsource-3.2.5-1.el9.x86_64
Last metadata expiration check: 0:00:20 ago on Mon Feb  3 03:26:20 2025.
Dependencies resolved.
=============================================================================================================================================================================
 Package                                                      Architecture                 Version                             Repository                               Size
=============================================================================================================================================================================
Installing:
 postgresql17-pgdg-pgroonga-debugsource                       x86_64                       3.2.5-1.el9                         groonga-almalinux                       117 k

Transaction Summary
=============================================================================================================================================================================
Install  1 Package

Total download size: 117 k
Installed size: 704 k
Downloading Packages:
postgresql17-pgdg-pgroonga-debugsource-3.2.5-1.el9.x86_64.rpm                                                                                269 kB/s | 117 kB     00:00    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                        267 kB/s | 117 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                     1/1 
  Installing       : postgresql17-pgdg-pgroonga-debugsource-3.2.5-1.el9.x86_64                                                                                           1/1 
  Verifying        : postgresql17-pgdg-pgroonga-debugsource-3.2.5-1.el9.x86_64                                                                                           1/1 

Installed:
  postgresql17-pgdg-pgroonga-debugsource-3.2.5-1.el9.x86_64                                                                                                                  

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE TO '\''3.2.5'\'';'
ALTER EXTENSION pgroonga UPDATE TO '3.2.5';
ALTER EXTENSION
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE credentials
(
    id integer,
    name varchar,
    have_credential boolean
);
CREATE TABLE
INSERT INTO credentials
    (id, name, have_credential)
VALUES
    (1, 'Alice', true),
    (2, 'Bob', false);
INSERT 0 2
CREATE INDEX grnindex ON credentials
  USING pgroonga (have_credential pgroonga.bool_ops);
CREATE INDEX
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
EXPLAIN (COSTS OFF)
SELECT name
  FROM credentials
 WHERE have_credential = false;
                QUERY PLAN                
------------------------------------------
 Index Scan using grnindex on credentials
   Index Cond: (have_credential = false)
(2 rows)

SELECT name
  FROM credentials
 WHERE have_credential = false;
 name 
------
 Bob
(1 row)

DROP TABLE credentials;
DROP TABLE
```
