### PR TITLE
test: add tests for "pgroonga_varchar_array_ops" again

### DIFF
--- a/expected/term-search/varchar-array/compatibility/v1/contain-v2/bitmapscan.out
+++ b/expected/term-search/varchar-array/compatibility/v1/contain-v2/bitmapscan.out
@@ -1,0 +1,34 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (tags &> 'Groonga'::character varying)
+   ->  Bitmap Index Scan on pgroonga_memos_index
+         Index Cond: (tags &> 'Groonga'::character varying)
+(4 rows)
+
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+  title   |         tags         
+----------+----------------------
+ Groonga  | {Groonga}
+ PGroonga | {PostgreSQL,Groonga}
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/term-search/varchar-array/compatibility/v1/contain-v2/indexscan.out
+++ b/expected/term-search/varchar-array/compatibility/v1/contain-v2/indexscan.out
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+                      QUERY PLAN                      
+------------------------------------------------------
+ Index Scan using pgroonga_memos_index on memos
+   Index Cond: (tags &> 'Groonga'::character varying)
+(2 rows)
+
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+  title   |         tags         
+----------+----------------------
+ Groonga  | {Groonga}
+ PGroonga | {PostgreSQL,Groonga}
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/term-search/varchar-array/compatibility/v1/contain-v2/seqscan.out
+++ b/expected/term-search/varchar-array/compatibility/v1/contain-v2/seqscan.out
@@ -1,0 +1,22 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+  title   |         tags         
+----------+----------------------
+ Groonga  | {Groonga}
+ PGroonga | {PostgreSQL,Groonga}
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/term-search/varchar-array/contain-v1/bitmapscan.out
+++ b/expected/term-search/varchar-array/contain-v1/bitmapscan.out
@@ -1,0 +1,34 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Bitmap Heap Scan on memos
+   Recheck Cond: (tags %% 'Groonga'::character varying)
+   ->  Bitmap Index Scan on pgroonga_memos_index
+         Index Cond: (tags %% 'Groonga'::character varying)
+(4 rows)
+
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+  title   |         tags         
+----------+----------------------
+ Groonga  | {Groonga}
+ PGroonga | {PostgreSQL,Groonga}
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/term-search/varchar-array/contain-v1/indexscan.out
+++ b/expected/term-search/varchar-array/contain-v1/indexscan.out
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+                      QUERY PLAN                      
+------------------------------------------------------
+ Index Scan using pgroonga_memos_index on memos
+   Index Cond: (tags %% 'Groonga'::character varying)
+(2 rows)
+
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+  title   |         tags         
+----------+----------------------
+ Groonga  | {Groonga}
+ PGroonga | {PostgreSQL,Groonga}
+(2 rows)
+
+DROP TABLE memos;

--- a/sql/term-search/varchar-array/compatibility/v1/contain-v2/bitmapscan.sql
+++ b/sql/term-search/varchar-array/compatibility/v1/contain-v2/bitmapscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+
+DROP TABLE memos;

--- a/sql/term-search/varchar-array/compatibility/v1/contain-v2/indexscan.sql
+++ b/sql/term-search/varchar-array/compatibility/v1/contain-v2/indexscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+
+DROP TABLE memos;

--- a/sql/term-search/varchar-array/compatibility/v1/contain-v2/seqscan.sql
+++ b/sql/term-search/varchar-array/compatibility/v1/contain-v2/seqscan.sql
@@ -1,0 +1,21 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+SELECT title, tags
+  FROM memos
+ WHERE tags &> 'Groonga';
+
+DROP TABLE memos;

--- a/sql/term-search/varchar-array/contain-v1/bitmapscan.sql
+++ b/sql/term-search/varchar-array/contain-v1/bitmapscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+
+DROP TABLE memos;

--- a/sql/term-search/varchar-array/contain-v1/indexscan.sql
+++ b/sql/term-search/varchar-array/contain-v1/indexscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE memos (
+  title text,
+  tags varchar(1023)[]
+);
+
+INSERT INTO memos VALUES ('PostgreSQL', ARRAY['PostgreSQL']);
+INSERT INTO memos VALUES ('Groonga', ARRAY['Groonga']);
+INSERT INTO memos VALUES ('PGroonga', ARRAY['PostgreSQL', 'Groonga']);
+
+CREATE INDEX pgroonga_memos_index ON memos
+  USING pgroonga (tags pgroonga_varchar_array_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+
+SELECT title, tags
+  FROM memos
+ WHERE tags %% 'Groonga';
+
+DROP TABLE memos;


### PR DESCRIPTION
I removed these tests in GH-657.
However, this is mistake.
These tests for "pgroonga_varchar_array_ops" not "pgroonga.varchar_array_ops".