### PR TITLE
pgroonga: remove pgroonga.int8_ops operator class

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -8,3 +8,4 @@ DROP OPERATOR FAMILY pgroonga.varchar_array_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.bool_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.int2_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.int4_ops USING pgroonga;
+DROP OPERATOR FAMILY pgroonga.int8_ops USING pgroonga;

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -63,3 +63,11 @@ CREATE OPERATOR CLASS pgroonga.int4_ops FOR TYPE int4
         OPERATOR 3 =,
         OPERATOR 4 >=,
         OPERATOR 5 >;
+
+CREATE OPERATOR CLASS pgroonga.int8_ops FOR TYPE int8
+    USING pgroonga AS
+        OPERATOR 1 <,
+        OPERATOR 2 <=,
+        OPERATOR 3 =,
+        OPERATOR 4 >=,
+        OPERATOR 5 >;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -3133,14 +3133,6 @@ BEGIN
 			PARALLEL SAFE;
 
 		/* v1 */
-		CREATE OPERATOR CLASS pgroonga.int8_ops FOR TYPE int8
-			USING pgroonga AS
-				OPERATOR 1 <,
-				OPERATOR 2 <=,
-				OPERATOR 3 =,
-				OPERATOR 4 >=,
-				OPERATOR 5 >;
-
 		CREATE OPERATOR CLASS pgroonga.float4_ops FOR TYPE float4
 			USING pgroonga AS
 				OPERATOR 1 <,


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because `pgroonga.int8_ops` is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.int8_ops" ./*
./data/pgroonga--3.2.5.sql:		CREATE OPERATOR CLASS pgroonga.int8_ops FOR TYPE int8
./data/pgroonga--4.0.0--3.2.5.sql:CREATE OPERATOR CLASS pgroonga.int8_ops FOR TYPE int8
./data/pgroonga--3.2.5--4.0.0.sql:DROP OPERATOR FAMILY pgroonga.int8_ops USING pgroonga;
```

---

Result of upgrade test:

```
+ sudo dnf install -y /host/almalinux/9/x86_64/Packages/postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64.rpm
Last metadata expiration check: 0:01:26 ago on Mon Feb  3 07:58:16 2025.
Dependencies resolved.
=============================================================================================================================================================================
 Package                                              Architecture                     Version                                  Repository                              Size
=============================================================================================================================================================================
Upgrading:
 postgresql17-pgdg-pgroonga                           x86_64                           4.0.0-1.el9                              @commandline                           768 k

Transaction Summary
=============================================================================================================================================================================
Upgrade  1 Package

Total size: 768 k
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                     1/1 
  Upgrading        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       2/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       1/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       2/2 

Upgraded:
  postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                              

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE;'
ALTER EXTENSION pgroonga UPDATE;
ALTER EXTENSION
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE numbers (
  number1 int8,
  number2 int8
);
CREATE TABLE
INSERT INTO numbers VALUES (2,  20);
INSERT 0 1
INSERT INTO numbers VALUES (7,  70);
INSERT 0 1
INSERT INTO numbers VALUES (6,  60);
INSERT 0 1
INSERT INTO numbers VALUES (4,  40);
INSERT 0 1
INSERT INTO numbers VALUES (5,  50);
INSERT 0 1
INSERT INTO numbers VALUES (8,  80);
INSERT 0 1
INSERT INTO numbers VALUES (1,  10);
INSERT 0 1
INSERT INTO numbers VALUES (10, 100);
INSERT 0 1
INSERT INTO numbers VALUES (3,  30);
INSERT 0 1
INSERT INTO numbers VALUES (9,  90);
INSERT 0 1
CREATE INDEX grnindex ON numbers
  USING pgroonga (number1 pgroonga.int8_ops,
                  number2 pgroonga.int8_ops);
ERROR:  operator class "pgroonga.int8_ops" does not exist for access method "pgroonga"
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
EXPLAIN (COSTS OFF)
SELECT number1, number2
  FROM numbers
 WHERE number1 >= 3 AND number2 >= 50
 ORDER BY number1 ASC;
                      QUERY PLAN                      
------------------------------------------------------
 Sort
   Sort Key: number1
   ->  Seq Scan on numbers
         Filter: ((number1 >= 3) AND (number2 >= 50))
(4 rows)

SELECT number1, number2
  FROM numbers
 WHERE number1 >= 3 AND number2 >= 50
 ORDER BY number1 ASC;
 number1 | number2 
---------+---------
       5 |      50
       6 |      60
       7 |      70
       8 |      80
       9 |      90
      10 |     100
(6 rows)

DROP TABLE numbers;
DROP TABLE
```

Result of downgrade test:

```
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE TO '\''3.2.5'\'';'
ALTER EXTENSION pgroonga UPDATE TO '3.2.5';
ALTER EXTENSION
+ sudo dnf install -y postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64
Last metadata expiration check: 0:01:27 ago on Mon Feb  3 07:58:16 2025.
Dependencies resolved.
=============================================================================================================================================================================
 Package                                             Architecture                    Version                                Repository                                  Size
=============================================================================================================================================================================
Downgrading:
 postgresql17-pgdg-pgroonga                          x86_64                          3.2.5-1.el9                            groonga-almalinux                          768 k

Transaction Summary
=============================================================================================================================================================================
Downgrade  1 Package

Total download size: 768 k
Downloading Packages:
postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64.rpm                                                                                            921 kB/s | 768 kB     00:00    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                        919 kB/s | 768 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                     1/1 
  Downgrading      : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       2/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                       1/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                       2/2 

Downgraded:
  postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                              

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE numbers (
  number1 int8,
  number2 int8
);
CREATE TABLE
INSERT INTO numbers VALUES (2,  20);
INSERT 0 1
INSERT INTO numbers VALUES (7,  70);
INSERT 0 1
INSERT INTO numbers VALUES (6,  60);
INSERT 0 1
INSERT INTO numbers VALUES (4,  40);
INSERT 0 1
INSERT INTO numbers VALUES (5,  50);
INSERT 0 1
INSERT INTO numbers VALUES (8,  80);
INSERT 0 1
INSERT INTO numbers VALUES (1,  10);
INSERT 0 1
INSERT INTO numbers VALUES (10, 100);
INSERT 0 1
INSERT INTO numbers VALUES (3,  30);
INSERT 0 1
INSERT INTO numbers VALUES (9,  90);
INSERT 0 1
CREATE INDEX grnindex ON numbers
  USING pgroonga (number1 pgroonga.int8_ops,
                  number2 pgroonga.int8_ops);
CREATE INDEX
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
EXPLAIN (COSTS OFF)
SELECT number1, number2
  FROM numbers
 WHERE number1 >= 3 AND number2 >= 50
 ORDER BY number1 ASC;
                   QUERY PLAN                   
------------------------------------------------
 Index Scan using grnindex on numbers
   Filter: ((number1 >= 3) AND (number2 >= 50))
(2 rows)

SELECT number1, number2
  FROM numbers
 WHERE number1 >= 3 AND number2 >= 50
 ORDER BY number1 ASC;
 number1 | number2 
---------+---------
       5 |      50
       6 |      60
       7 |      70
       8 |      80
       9 |      90
      10 |     100
(6 rows)

DROP TABLE numbers;
DROP TABLE
```