### PR TITLE
pgroonga: remove pgroonga.float4_ops operator class

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -9,6 +9,7 @@ DROP OPERATOR FAMILY pgroonga.bool_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.int2_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.int4_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.int8_ops USING pgroonga;
+DROP OPERATOR FAMILY pgroonga.float4_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.timestamp_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.timestamptz_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.jsonb_ops USING pgroonga;

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -72,6 +72,14 @@ CREATE OPERATOR CLASS pgroonga.int8_ops FOR TYPE int8
         OPERATOR 4 >=,
         OPERATOR 5 >;
 
+CREATE OPERATOR CLASS pgroonga.float4_ops FOR TYPE float4
+    USING pgroonga AS
+        OPERATOR 1 <,
+        OPERATOR 2 <=,
+        OPERATOR 3 =,
+        OPERATOR 4 >=,
+        OPERATOR 5 >;
+
 CREATE OPERATOR CLASS pgroonga.timestamp_ops FOR TYPE timestamp
     USING pgroonga AS
         OPERATOR 1 <,

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -3133,14 +3133,6 @@ BEGIN
 			PARALLEL SAFE;
 
 		/* v1 */
-		CREATE OPERATOR CLASS pgroonga.float4_ops FOR TYPE float4
-			USING pgroonga AS
-				OPERATOR 1 <,
-				OPERATOR 2 <=,
-				OPERATOR 3 =,
-				OPERATOR 4 >=,
-				OPERATOR 5 >;
-
 		CREATE OPERATOR CLASS pgroonga.float8_ops FOR TYPE float8
 			USING pgroonga AS
 				OPERATOR 1 <,


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because `pgroonga.float4_ops` is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.float4_ops" ./*
./data/pgroonga--3.2.5.sql:		CREATE OPERATOR CLASS pgroonga.float4_ops FOR TYPE float4
./data/pgroonga--4.0.0--3.2.5.sql:CREATE OPERATOR CLASS pgroonga.float4_ops FOR TYPE float4
./data/pgroonga--3.2.5--4.0.0.sql:DROP OPERATOR FAMILY pgroonga.float4_ops USING pgroonga;
```

We can't set `pgroonga.float4_ops` now because the latest released Groonga doesn't support it. Groonga 15.0.0 will add support for `float4`.
So, PGroonga outputs the following error in downgrade test. However, this is expected behavior for now.

```
ERROR:  pgroonga: [insert] failed to set column value: [column][fix][set-value][BuildingSources17251.id] too long value: <8>: max:<4>
```

---

The result of upgrade test:

```
+ sudo dnf install -y /host/almalinux/9/x86_64/Packages/postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64.rpm
Last metadata expiration check: 0:00:37 ago on Wed Feb  5 09:12:58 2025.
Dependencies resolved.
============================================================================================================================================================================================
 Package                                                  Architecture                         Version                                     Repository                                  Size
============================================================================================================================================================================================
Upgrading:
 postgresql17-pgdg-pgroonga                               x86_64                               4.0.0-1.el9                                 @commandline                               775 k

Transaction Summary
============================================================================================================================================================================================
Upgrade  1 Package

Total size: 775 k
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                    1/1 
  Upgrading        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      2/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      1/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      2/2 

Upgraded:
  postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                                             

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE;'
ALTER EXTENSION pgroonga UPDATE;
ALTER EXTENSION
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE memos (
  id real
);
CREATE TABLE
INSERT INTO memos VALUES (1.1);
INSERT 0 1
INSERT INTO memos VALUES (2.1);
INSERT 0 1
INSERT INTO memos VALUES (3.1);
INSERT 0 1
CREATE INDEX grnindex ON memos
  USING pgroonga (id pgroonga.float4_ops);
ERROR:  operator class "pgroonga.float4_ops" does not exist for access method "pgroonga"
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
EXPLAIN (COSTS OFF)
SELECT id
  FROM memos
 WHERE id >= '2.1';
          QUERY PLAN           
-------------------------------
 Seq Scan on memos
   Filter: (id >= '2.1'::real)
(2 rows)

SELECT id
  FROM memos
 WHERE id >= '2.1';
 id  
-----
 2.1
 3.1
(2 rows)

DROP TABLE memos;
DROP TABLE
```

The result of downgrade test:

```
+ sudo dnf install -y postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64
Last metadata expiration check: 0:00:37 ago on Wed Feb  5 09:12:58 2025.
Dependencies resolved.
============================================================================================================================================================================================
 Package                                                 Architecture                        Version                                   Repository                                      Size
============================================================================================================================================================================================
Downgrading:
 postgresql17-pgdg-pgroonga                              x86_64                              3.2.5-1.el9                               groonga-almalinux                              768 k

Transaction Summary
============================================================================================================================================================================================
Downgrade  1 Package

Total download size: 768 k
Downloading Packages:
postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64.rpm                                                                                                           497 kB/s | 768 kB     00:01    
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                       496 kB/s | 768 kB     00:01     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                    1/1 
  Downgrading      : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      2/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      1/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      2/2 

Downgraded:
  postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                                             

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE memos (
  id real
);
CREATE TABLE
INSERT INTO memos VALUES (1.1);
INSERT 0 1
INSERT INTO memos VALUES (2.1);
INSERT 0 1
INSERT INTO memos VALUES (3.1);
INSERT 0 1
CREATE INDEX grnindex ON memos
  USING pgroonga (id pgroonga.float4_ops);
ERROR:  pgroonga: [insert] failed to set column value: [column][fix][set-value][BuildingSources17251.id] too long value: <8>: max:<4>
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
EXPLAIN (COSTS OFF)
SELECT id
  FROM memos
 WHERE id >= '2.1';
          QUERY PLAN           
-------------------------------
 Seq Scan on memos
   Filter: (id >= '2.1'::real)
(2 rows)

SELECT id
  FROM memos
 WHERE id >= '2.1';
 id  
-----
 2.1
 3.1
(2 rows)

DROP TABLE memos;
DROP TABLE
```