### PR TITLE
pgroonga_float4_ops: fix a bug that we can't specify pgroonga_float4_ops in index

### DIFF
--- a/expected/compare/float4/single/any/equal/empty/bitmapscan.out
+++ b/expected/compare/float4/single/any/equal/empty/bitmapscan.out
@@ -1,0 +1,34 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Bitmap Heap Scan on ids
+         Recheck Cond: (id = ANY ('{}'::real[]))
+         ->  Bitmap Index Scan on pgroonga_index
+               Index Cond: (id = ANY ('{}'::real[]))
+(6 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+ id 
+----
+(0 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/any/equal/empty/indexscan.out
+++ b/expected/compare/float4/single/any/equal/empty/indexscan.out
@@ -1,0 +1,30 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+               QUERY PLAN                
+-----------------------------------------
+ Index Scan using pgroonga_index on ids
+   Index Cond: (id = ANY ('{}'::real[]))
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+ id 
+----
+(0 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/any/equal/empty/seqscan.out
+++ b/expected/compare/float4/single/any/equal/empty/seqscan.out
@@ -1,0 +1,32 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+                QUERY PLAN                 
+-------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Seq Scan on ids
+         Filter: (id = ANY ('{}'::real[]))
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+ id 
+----
+(0 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/any/equal/multiple/bitmapscan.out
+++ b/expected/compare/float4/single/any/equal/multiple/bitmapscan.out
@@ -1,0 +1,44 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Bitmap Heap Scan on ids
+         Recheck Cond: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+         ->  Bitmap Index Scan on pgroonga_index
+               Index Cond: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+(6 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+ id  
+-----
+ 1.1
+ 6.1
+ 7.1
+(3 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/any/equal/multiple/indexscan.out
+++ b/expected/compare/float4/single/any/equal/multiple/indexscan.out
@@ -1,0 +1,40 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Index Scan using pgroonga_index on ids
+   Index Cond: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+ id  
+-----
+ 1.1
+ 6.1
+ 7.1
+(3 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/any/equal/multiple/seqscan.out
+++ b/expected/compare/float4/single/any/equal/multiple/seqscan.out
@@ -1,0 +1,42 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Seq Scan on ids
+         Filter: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+ id  
+-----
+ 1.1
+ 6.1
+ 7.1
+(3 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/between/bitmapscan.out
+++ b/expected/compare/float4/single/between/bitmapscan.out
@@ -1,0 +1,47 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Bitmap Heap Scan on ids
+         Recheck Cond: ((id >= '3'::real) AND (id <= '9'::real))
+         ->  Bitmap Index Scan on grnindex
+               Index Cond: ((id >= '3'::real) AND (id <= '9'::real))
+(6 rows)
+
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+ id  
+-----
+ 3.1
+ 4.1
+ 5.1
+ 6.1
+ 7.1
+ 8.1
+(6 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/between/indexscan.out
+++ b/expected/compare/float4/single/between/indexscan.out
@@ -1,0 +1,43 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+                       QUERY PLAN                        
+---------------------------------------------------------
+ Index Scan using grnindex on ids
+   Index Cond: ((id >= '3'::real) AND (id <= '9'::real))
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+ id  
+-----
+ 3.1
+ 4.1
+ 5.1
+ 6.1
+ 7.1
+ 8.1
+(6 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/between/seqscan.out
+++ b/expected/compare/float4/single/between/seqscan.out
@@ -1,0 +1,45 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Seq Scan on ids
+         Filter: ((id >= '3'::real) AND (id <= '9'::real))
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+ id  
+-----
+ 3.1
+ 4.1
+ 5.1
+ 6.1
+ 7.1
+ 8.1
+(6 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/equal/bitmapscan.out
+++ b/expected/compare/float4/single/equal/bitmapscan.out
@@ -1,0 +1,31 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+               QUERY PLAN               
+----------------------------------------
+ Bitmap Heap Scan on ids
+   Recheck Cond: (id = '2.1'::real)
+   ->  Bitmap Index Scan on grnindex
+         Index Cond: (id = '2.1'::real)
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+ id  
+-----
+ 2.1
+(1 row)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/equal/indexscan.out
+++ b/expected/compare/float4/single/equal/indexscan.out
@@ -1,0 +1,29 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+            QUERY PLAN            
+----------------------------------
+ Index Scan using grnindex on ids
+   Index Cond: (id = '2.1'::real)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+ id  
+-----
+ 2.1
+(1 row)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/equal/multiple.out
+++ b/expected/compare/float4/single/equal/multiple.out
@@ -1,0 +1,34 @@
+CREATE TABLE numbers (
+  number1 real,
+  number2 real
+);
+INSERT INTO numbers VALUES (2.1,  20.1);
+INSERT INTO numbers VALUES (7.1,  70.1);
+INSERT INTO numbers VALUES (6.1,  60.1);
+CREATE INDEX grnindex
+    ON numbers
+ USING pgroonga (number1 pgroonga_float4_ops, number2 pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 = (6.1::real) AND number2 = (60.1::real)
+ ORDER BY number1 ASC;
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Index Scan using grnindex on numbers
+   Index Cond: ((number1 = '6.1'::real) AND (number2 = '60.1'::real))
+(2 rows)
+
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 = (6.1::real) AND number2 = (60.1::real)
+ ORDER BY number1 ASC;
+ number1 | number2 
+---------+---------
+     6.1 |    60.1
+(1 row)
+
+DROP TABLE numbers;

--- a/expected/compare/float4/single/equal/seqscan.out
+++ b/expected/compare/float4/single/equal/seqscan.out
@@ -1,0 +1,29 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+          QUERY PLAN          
+------------------------------
+ Seq Scan on ids
+   Filter: (id = '2.1'::real)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+ id  
+-----
+ 2.1
+(1 row)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/greater-than-equal/bitmapscan.out
+++ b/expected/compare/float4/single/greater-than-equal/bitmapscan.out
@@ -1,0 +1,32 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+               QUERY PLAN                
+-----------------------------------------
+ Bitmap Heap Scan on ids
+   Recheck Cond: (id >= '2.1'::real)
+   ->  Bitmap Index Scan on grnindex
+         Index Cond: (id >= '2.1'::real)
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+ id  
+-----
+ 2.1
+ 3.1
+(2 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/greater-than-equal/indexscan.out
+++ b/expected/compare/float4/single/greater-than-equal/indexscan.out
@@ -1,0 +1,30 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+            QUERY PLAN             
+-----------------------------------
+ Index Scan using grnindex on ids
+   Index Cond: (id >= '2.1'::real)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+ id  
+-----
+ 2.1
+ 3.1
+(2 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/greater-than-equal/multiple.out
+++ b/expected/compare/float4/single/greater-than-equal/multiple.out
@@ -1,0 +1,35 @@
+CREATE TABLE numbers (
+  number1 real,
+  number2 real
+);
+INSERT INTO numbers VALUES (2.1,  20.1);
+INSERT INTO numbers VALUES (7.1,  70.1);
+INSERT INTO numbers VALUES (6.1,  60.1);
+CREATE INDEX grnindex
+    ON numbers
+ USING pgroonga (number1 pgroonga_float4_ops, number2 pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 >= (6.1::real) AND number2 >= (50.66::real)
+ ORDER BY number1 ASC;
+                               QUERY PLAN                                
+-------------------------------------------------------------------------
+ Index Scan using grnindex on numbers
+   Index Cond: ((number1 >= '6.1'::real) AND (number2 >= '50.66'::real))
+(2 rows)
+
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 >= (6.1::real) AND number2 >= (50.66::real)
+ ORDER BY number1 ASC;
+ number1 | number2 
+---------+---------
+     6.1 |    60.1
+     7.1 |    70.1
+(2 rows)
+
+DROP TABLE numbers;

--- a/expected/compare/float4/single/greater-than-equal/seqscan.out
+++ b/expected/compare/float4/single/greater-than-equal/seqscan.out
@@ -1,0 +1,30 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+          QUERY PLAN           
+-------------------------------
+ Seq Scan on ids
+   Filter: (id >= '2.1'::real)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+ id  
+-----
+ 2.1
+ 3.1
+(2 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/in/bitmapscan.out
+++ b/expected/compare/float4/single/in/bitmapscan.out
@@ -1,0 +1,44 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+                           QUERY PLAN                           
+----------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Bitmap Heap Scan on ids
+         Recheck Cond: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+         ->  Bitmap Index Scan on pgroonga_index
+               Index Cond: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+(6 rows)
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+ id  
+-----
+ 1.1
+ 6.1
+ 7.1
+(3 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/in/indexscan.out
+++ b/expected/compare/float4/single/in/indexscan.out
@@ -1,0 +1,40 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Index Scan using pgroonga_index on ids
+   Index Cond: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+ id  
+-----
+ 1.1
+ 6.1
+ 7.1
+(3 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/in/null/bitmapscan.out
+++ b/expected/compare/float4/single/in/null/bitmapscan.out
@@ -1,0 +1,43 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+                           QUERY PLAN                            
+-----------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Bitmap Heap Scan on ids
+         Recheck Cond: (id = ANY ('{6.1,NULL,7.1}'::real[]))
+         ->  Bitmap Index Scan on pgroonga_index
+               Index Cond: (id = ANY ('{6.1,NULL,7.1}'::real[]))
+(6 rows)
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+ id  
+-----
+ 6.1
+ 7.1
+(2 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/in/null/indexscan.out
+++ b/expected/compare/float4/single/in/null/indexscan.out
@@ -1,0 +1,39 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Index Scan using pgroonga_index on ids
+   Index Cond: (id = ANY ('{6.1,NULL,7.1}'::real[]))
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+ id  
+-----
+ 6.1
+ 7.1
+(2 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/in/null/seqscan.out
+++ b/expected/compare/float4/single/in/null/seqscan.out
@@ -1,0 +1,41 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+                      QUERY PLAN                       
+-------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Seq Scan on ids
+         Filter: (id = ANY ('{6.1,NULL,7.1}'::real[]))
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+ id  
+-----
+ 6.1
+ 7.1
+(2 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/in/seqscan.out
+++ b/expected/compare/float4/single/in/seqscan.out
@@ -1,0 +1,42 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Seq Scan on ids
+         Filter: (id = ANY ('{6.1,1.1,7.1}'::real[]))
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+ id  
+-----
+ 1.1
+ 6.1
+ 7.1
+(3 rows)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/bitmapscan.out
+++ b/expected/compare/float4/single/less-than-equal/bitmapscan.out
@@ -1,0 +1,31 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+              QUERY PLAN               
+---------------------------------------
+ Bitmap Heap Scan on ids
+   Recheck Cond: (id <= '2'::real)
+   ->  Bitmap Index Scan on grnindex
+         Index Cond: (id <= '2'::real)
+(4 rows)
+
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+ id  
+-----
+ 1.1
+(1 row)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/indexscan.out
+++ b/expected/compare/float4/single/less-than-equal/indexscan.out
@@ -1,0 +1,29 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+            QUERY PLAN            
+----------------------------------
+ Index Scan using grnindex on ids
+   Index Cond: (id <= '2'::real)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+ id  
+-----
+ 1.1
+(1 row)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/multiple.out
+++ b/expected/compare/float4/single/less-than-equal/multiple.out
@@ -32,7 +32,9 @@ SELECT id
  ORDER BY id ASC;
  id  
 -----
+ 1.1
  2.1
+ 3.1
 (1 row)
 
 DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/multiple.out
+++ b/expected/compare/float4/single/less-than-equal/multiple.out
@@ -1,0 +1,38 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (5.1::real) AND id <= (3.1::real)
+ ORDER BY id ASC;
+                         QUERY PLAN                          
+-------------------------------------------------------------
+ Index Scan using grnindex on ids
+   Index Cond: ((id <= '5.1'::real) AND (id <= '3.1'::real))
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id <= (5.1::real) AND id <= (3.1::real)
+ ORDER BY id ASC;
+ id  
+-----
+ 2.1
+(1 row)
+
+DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/multiple.out
+++ b/expected/compare/float4/single/less-than-equal/multiple.out
@@ -35,6 +35,6 @@ SELECT id
  1.1
  2.1
  3.1
-(1 row)
+(3 row)
 
 DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/multiple.out
+++ b/expected/compare/float4/single/less-than-equal/multiple.out
@@ -35,6 +35,6 @@ SELECT id
  1.1
  2.1
  3.1
-(3 row)
+(3 rows)
 
 DROP TABLE ids;

--- a/expected/compare/float4/single/less-than-equal/seqscan.out
+++ b/expected/compare/float4/single/less-than-equal/seqscan.out
@@ -1,0 +1,29 @@
+CREATE TABLE ids (
+  id real
+);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+         QUERY PLAN          
+-----------------------------
+ Seq Scan on ids
+   Filter: (id <= '2'::real)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+ id  
+-----
+ 1.1
+(1 row)
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/any/equal/empty/bitmapscan.sql
+++ b/sql/compare/float4/single/any/equal/empty/bitmapscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/any/equal/empty/indexscan.sql
+++ b/sql/compare/float4/single/any/equal/empty/indexscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/any/equal/empty/seqscan.sql
+++ b/sql/compare/float4/single/any/equal/empty/seqscan.sql
@@ -1,0 +1,26 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[]::real[])
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/any/equal/multiple/bitmapscan.sql
+++ b/sql/compare/float4/single/any/equal/multiple/bitmapscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/any/equal/multiple/indexscan.sql
+++ b/sql/compare/float4/single/any/equal/multiple/indexscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/any/equal/multiple/seqscan.sql
+++ b/sql/compare/float4/single/any/equal/multiple/seqscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id = ANY(ARRAY[6.1, 1.1, 7.1]::real[])
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/between/bitmapscan.sql
+++ b/sql/compare/float4/single/between/bitmapscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/between/indexscan.sql
+++ b/sql/compare/float4/single/between/indexscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/between/seqscan.sql
+++ b/sql/compare/float4/single/between/seqscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id BETWEEN (3.0::real) AND (9.0::real)
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/equal/bitmapscan.sql
+++ b/sql/compare/float4/single/equal/bitmapscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/equal/indexscan.sql
+++ b/sql/compare/float4/single/equal/indexscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/equal/multiple.sql
+++ b/sql/compare/float4/single/equal/multiple.sql
@@ -1,0 +1,29 @@
+CREATE TABLE numbers (
+  number1 real,
+  number2 real
+);
+
+INSERT INTO numbers VALUES (2.1,  20.1);
+INSERT INTO numbers VALUES (7.1,  70.1);
+INSERT INTO numbers VALUES (6.1,  60.1);
+
+CREATE INDEX grnindex
+    ON numbers
+ USING pgroonga (number1 pgroonga_float4_ops, number2 pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 = (6.1::real) AND number2 = (60.1::real)
+ ORDER BY number1 ASC;
+
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 = (6.1::real) AND number2 = (60.1::real)
+ ORDER BY number1 ASC;
+
+DROP TABLE numbers;

--- a/sql/compare/float4/single/equal/seqscan.sql
+++ b/sql/compare/float4/single/equal/seqscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+
+SELECT id
+  FROM ids
+ WHERE id = (2.1::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/greater-than-equal/bitmapscan.sql
+++ b/sql/compare/float4/single/greater-than-equal/bitmapscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/greater-than-equal/indexscan.sql
+++ b/sql/compare/float4/single/greater-than-equal/indexscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/greater-than-equal/multiple.sql
+++ b/sql/compare/float4/single/greater-than-equal/multiple.sql
@@ -1,0 +1,29 @@
+CREATE TABLE numbers (
+  number1 real,
+  number2 real
+);
+
+INSERT INTO numbers VALUES (2.1,  20.1);
+INSERT INTO numbers VALUES (7.1,  70.1);
+INSERT INTO numbers VALUES (6.1,  60.1);
+
+CREATE INDEX grnindex
+    ON numbers
+ USING pgroonga (number1 pgroonga_float4_ops, number2 pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 >= (6.1::real) AND number2 >= (50.66::real)
+ ORDER BY number1 ASC;
+
+SELECT number1, number2
+  FROM numbers
+ WHERE number1 >= (6.1::real) AND number2 >= (50.66::real)
+ ORDER BY number1 ASC;
+
+DROP TABLE numbers;

--- a/sql/compare/float4/single/greater-than-equal/seqscan.sql
+++ b/sql/compare/float4/single/greater-than-equal/seqscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+
+SELECT id
+  FROM ids
+ WHERE id >= (2.1::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/in/bitmapscan.sql
+++ b/sql/compare/float4/single/in/bitmapscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/in/indexscan.sql
+++ b/sql/compare/float4/single/in/indexscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/in/null/bitmapscan.sql
+++ b/sql/compare/float4/single/in/null/bitmapscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/in/null/indexscan.sql
+++ b/sql/compare/float4/single/in/null/indexscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/in/null/seqscan.sql
+++ b/sql/compare/float4/single/in/null/seqscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), NULL, (7.1::real))
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/in/seqscan.sql
+++ b/sql/compare/float4/single/in/seqscan.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX pgroonga_index ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id IN ((6.1::real), (1.1::real), (7.1::real))
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/less-than-equal/bitmapscan.sql
+++ b/sql/compare/float4/single/less-than-equal/bitmapscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/less-than-equal/indexscan.sql
+++ b/sql/compare/float4/single/less-than-equal/indexscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/less-than-equal/multiple.sql
+++ b/sql/compare/float4/single/less-than-equal/multiple.sql
@@ -1,0 +1,33 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (7.1);
+INSERT INTO ids VALUES (6.1);
+INSERT INTO ids VALUES (4.1);
+INSERT INTO ids VALUES (5.1);
+INSERT INTO ids VALUES (8.1);
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (10.1);
+INSERT INTO ids VALUES (3.1);
+INSERT INTO ids VALUES (9.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (5.1::real) AND id <= (3.1::real)
+ ORDER BY id ASC;
+
+SELECT id
+  FROM ids
+ WHERE id <= (5.1::real) AND id <= (3.1::real)
+ ORDER BY id ASC;
+
+DROP TABLE ids;

--- a/sql/compare/float4/single/less-than-equal/seqscan.sql
+++ b/sql/compare/float4/single/less-than-equal/seqscan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE ids (
+  id real
+);
+
+INSERT INTO ids VALUES (1.1);
+INSERT INTO ids VALUES (2.1);
+INSERT INTO ids VALUES (3.1);
+
+CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
+
+SET enable_seqscan = on;
+SET enable_indexscan = off;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+
+SELECT id
+  FROM ids
+ WHERE id <= (2.0::real);
+
+DROP TABLE ids;

--- a/src/pgrn-convert.c
+++ b/src/pgrn-convert.c
@@ -99,7 +99,7 @@ PGrnConvertFromData(Datum datum, Oid typeID, grn_obj *buffer)
 		GRN_INT64_SET(ctx, buffer, DatumGetInt64(datum));
 		break;
 	case FLOAT4OID:
-		GRN_FLOAT_SET(ctx, buffer, DatumGetFloat4(datum));
+		GRN_FLOAT32_SET(ctx, buffer, DatumGetFloat4(datum));
 		break;
 	case FLOAT8OID:
 		GRN_FLOAT_SET(ctx, buffer, DatumGetFloat8(datum));

--- a/src/pgrn-wal.c
+++ b/src/pgrn-wal.c
@@ -953,6 +953,9 @@ PGrnWALInsertColumnValueRawGeneric(PGrnWALData *data,
 	case GRN_DB_UINT64:
 		msgpack_pack_uint64(packer, *((uint64_t *) (value)));
 		break;
+	case GRN_DB_FLOAT32:
+		msgpack_pack_floatdouble(packer, *((float *) (value)));
+		break;
 	case GRN_DB_FLOAT:
 		msgpack_pack_double(packer, *((double *) (value)));
 		break;
@@ -2291,6 +2294,9 @@ PGrnWALApplyInsertArray(PGrnWALApplyData *data,
 			}
 			break;
 #	undef ELEMENT_VALUE
+		case MSGPACK_OBJECT_FLOAT32:
+			GRN_FLOAT32_PUT(ctx, value, element->via.f32);
+			break;
 		case MSGPACK_OBJECT_FLOAT:
 			GRN_FLOAT_PUT(ctx, value, element->via.f64);
 			break;
@@ -2395,6 +2401,10 @@ PGrnWALApplyInsert(PGrnWALApplyData *data,
 		case MSGPACK_OBJECT_NEGATIVE_INTEGER:
 			grn_obj_reinit(ctx, walValue, GRN_DB_INT64, 0);
 			GRN_INT64_SET(ctx, walValue, value->via.i64);
+			break;
+		case MSGPACK_OBJECT_FLOAT32:
+			grn_obj_reinit(ctx, walValue, GRN_DB_FLOAT32, 0);
+			GRN_FLOAT32_SET(ctx, walValue, value->via.f32);
 			break;
 		case MSGPACK_OBJECT_FLOAT:
 			grn_obj_reinit(ctx, walValue, GRN_DB_FLOAT, 0);
@@ -2766,6 +2776,17 @@ PGrnWALApplyObject(PGrnWALApplyData *data, msgpack_object *object)
 						currentBlock,
 						currentOffset,
 						object->via.u64);
+			break;
+		case MSGPACK_OBJECT_FLOAT32:
+			PGrnCheckRC(GRN_INVALID_ARGUMENT,
+						"%s[%s(%u)] %s: <%u><%u>: <float32>: <%g>",
+						tag,
+						RelationGetRelationName(data->index),
+						RelationGetRelid(data->index),
+						message,
+						currentBlock,
+						currentOffset,
+						object->via.f32);
 			break;
 		case MSGPACK_OBJECT_FLOAT:
 			PGrnCheckRC(GRN_INVALID_ARGUMENT,

--- a/src/pgrn-wal.c
+++ b/src/pgrn-wal.c
@@ -2295,9 +2295,9 @@ PGrnWALApplyInsertArray(PGrnWALApplyData *data,
 			break;
 #	undef ELEMENT_VALUE
 		case MSGPACK_OBJECT_FLOAT32:
-			GRN_FLOAT32_PUT(ctx, value, element->via.f32);
+			GRN_FLOAT32_PUT(ctx, value, element->via.f64);
 			break;
-		case MSGPACK_OBJECT_FLOAT:
+		case MSGPACK_OBJECT_FLOAT64:
 			GRN_FLOAT_PUT(ctx, value, element->via.f64);
 			break;
 		case MSGPACK_OBJECT_STR:
@@ -2404,9 +2404,9 @@ PGrnWALApplyInsert(PGrnWALApplyData *data,
 			break;
 		case MSGPACK_OBJECT_FLOAT32:
 			grn_obj_reinit(ctx, walValue, GRN_DB_FLOAT32, 0);
-			GRN_FLOAT32_SET(ctx, walValue, value->via.f32);
+			GRN_FLOAT32_SET(ctx, walValue, value->via.f64);
 			break;
-		case MSGPACK_OBJECT_FLOAT:
+		case MSGPACK_OBJECT_FLOAT64:
 			grn_obj_reinit(ctx, walValue, GRN_DB_FLOAT, 0);
 			GRN_FLOAT_SET(ctx, walValue, value->via.f64);
 			break;
@@ -2786,11 +2786,11 @@ PGrnWALApplyObject(PGrnWALApplyData *data, msgpack_object *object)
 						message,
 						currentBlock,
 						currentOffset,
-						object->via.f32);
+						object->via.f64);
 			break;
-		case MSGPACK_OBJECT_FLOAT:
+		case MSGPACK_OBJECT_FLOAT64:
 			PGrnCheckRC(GRN_INVALID_ARGUMENT,
-						"%s[%s(%u)] %s: <%u><%u>: <float>: <%g>",
+						"%s[%s(%u)] %s: <%u><%u>: <float64>: <%g>",
 						tag,
 						RelationGetRelationName(data->index),
 						RelationGetRelid(data->index),

--- a/src/pgrn-wal.c
+++ b/src/pgrn-wal.c
@@ -954,7 +954,7 @@ PGrnWALInsertColumnValueRawGeneric(PGrnWALData *data,
 		msgpack_pack_uint64(packer, *((uint64_t *) (value)));
 		break;
 	case GRN_DB_FLOAT32:
-		msgpack_pack_floatdouble(packer, *((float *) (value)));
+		msgpack_pack_float(packer, *((float *) (value)));
 		break;
 	case GRN_DB_FLOAT:
 		msgpack_pack_double(packer, *((double *) (value)));


### PR DESCRIPTION
PGroonga reports the following error when we specify `pgroonga_float4_ops` in index with Groonga 10.0.2 or later.

```sql
CREATE TABLE ids (
  id real
);

INSERT INTO ids VALUES (2.1);

CREATE INDEX grnindex ON ids USING pgroonga (id pgroonga_float4_ops);
ERROR:  pgroonga: [insert] failed to set column value: [column][fix][set-value][BuildingSources31238.id] too long value: <8>: max:<4>
```