### PR TITLE
pgroonga: remove pgroonga.score("row" record) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -1,5 +1,6 @@
 -- Upgrade SQL
 
+-- Remove operator classes
 DROP OPERATOR FAMILY pgroonga.text_full_text_search_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.text_array_full_text_search_ops USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops USING pgroonga;
@@ -22,3 +23,6 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+-- Remove finctions
+DROP FUNCTION pgroonga.score("row" record);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -1,5 +1,6 @@
 -- Downgrade SQL
 
+-- Create operator classes
 /* v1 */
 CREATE OPERATOR CLASS pgroonga.text_full_text_search_ops FOR TYPE text
     USING pgroonga AS
@@ -195,3 +196,12 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+-- Create finctions
+CREATE FUNCTION pgroonga.score("row" record)
+    RETURNS float8
+    AS 'MODULE_PATHNAME', 'pgroonga_score'
+    LANGUAGE C
+    VOLATILE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2614,14 +2614,6 @@ BEGIN
 	IF NOT FOUND THEN
 		CREATE SCHEMA pgroonga;
 
-		CREATE FUNCTION pgroonga.score("row" record)
-			RETURNS float8
-			AS 'MODULE_PATHNAME', 'pgroonga_score'
-			LANGUAGE C
-			VOLATILE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.table_name(indexName cstring)
 			RETURNS text
 			AS 'MODULE_PATHNAME', 'pgroonga_table_name'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because "pgroonga.score()" is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.score" ./*
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.score("row" record)
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.score("row" record)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.score("row" record)
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.score("row" record);
```

TODO:
* Resolve conflict

---

The result of upgrade test:

```
+ sudo dnf install -y /host/almalinux/9/x86_64/Packages/postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64.rpm
Last metadata expiration check: 0:00:42 ago on Wed Feb  5 12:49:25 2025.
Dependencies resolved.
============================================================================================================================================================================================
 Package                                                  Architecture                         Version                                     Repository                                  Size
============================================================================================================================================================================================
Upgrading:
 postgresql17-pgdg-pgroonga                               x86_64                               4.0.0-1.el9                                 @commandline                               775 k

Transaction Summary
============================================================================================================================================================================================
Upgrade  1 Package

Total size: 775 k
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                    1/1 
  Upgrading        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      2/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      1/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      2/2 

Upgraded:
  postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                                             

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE;'
ALTER EXTENSION pgroonga UPDATE;
ALTER EXTENSION
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE memos (
  id integer PRIMARY KEY,
  content text
);
CREATE TABLE
INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
INSERT 0 1
INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
INSERT 0 1
INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
INSERT 0 1
CREATE INDEX grnindex ON memos USING pgroonga (id, content);
CREATE INDEX
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
SELECT id, content, pgroonga.score(memos)
  FROM memos
 WHERE content %% 'PGroonga' AND content %% 'Groonga';
ERROR:  function pgroonga.score(memos) does not exist
LINE 1: SELECT id, content, pgroonga.score(memos)
                            ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
DROP TABLE memos;
DROP TABLE
```

The result of downgrade test:

```
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE TO '\''3.2.5'\'';'
ALTER EXTENSION pgroonga UPDATE TO '3.2.5';
ALTER EXTENSION
+ sudo dnf install -y postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64
Last metadata expiration check: 0:00:43 ago on Wed Feb  5 12:49:25 2025.
Dependencies resolved.
============================================================================================================================================================================================
 Package                                                 Architecture                        Version                                   Repository                                      Size
============================================================================================================================================================================================
Downgrading:
 postgresql17-pgdg-pgroonga                              x86_64                              3.2.5-1.el9                               groonga-almalinux                              768 k

Transaction Summary
============================================================================================================================================================================================
Downgrade  1 Package

Total download size: 768 k
Downloading Packages:
postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64.rpm                                                                                                           800 kB/s | 768 kB     00:00    
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                       798 kB/s | 768 kB     00:00     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                    1/1 
  Downgrading      : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      1/2 
  Cleanup          : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      2/2 
  Running scriptlet: postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      2/2 
  Verifying        : postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                      1/2 
  Verifying        : postgresql17-pgdg-pgroonga-4.0.0-1.el9.x86_64                                                                                                                      2/2 

Downgraded:
  postgresql17-pgdg-pgroonga-3.2.5-1.el9.x86_64                                                                                                                                             

Complete!
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
CREATE TABLE memos (
  id integer PRIMARY KEY,
  content text
);
CREATE TABLE
INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
INSERT 0 1
INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
INSERT 0 1
INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
INSERT 0 1
CREATE INDEX grnindex ON memos USING pgroonga (id, content);
CREATE INDEX
SET enable_seqscan = off;
SET
SET enable_indexscan = on;
SET
SET enable_bitmapscan = off;
SET
SELECT id, content, pgroonga.score(memos)
  FROM memos
 WHERE content %% 'PGroonga' AND content %% 'Groonga';
 id |                        content                        | score 
----+-------------------------------------------------------+-------
  3 | PGroonga is a PostgreSQL extension that uses Groonga. |     2
(1 row)

DROP TABLE memos;
DROP TABLE
```