### PR TITLE
pgroonga: remove pgroonga.table_name() function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.table_name(indexName cstring);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.table_name(indexName cstring)
+    RETURNS text
+    AS 'MODULE_PATHNAME', 'pgroonga_table_name'
+    LANGUAGE C
+    STABLE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2622,14 +2622,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.table_name(indexName cstring)
-			RETURNS text
-			AS 'MODULE_PATHNAME', 'pgroonga_table_name'
-			LANGUAGE C
-			STABLE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.command(groongaCommand text)
 			RETURNS text
 			AS 'MODULE_PATHNAME', 'pgroonga_command'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because `pgroonga.table_name()` is not used in PGroonga's tests as below.

```
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.table_name(indexName cstring)
./data/pgroonga--1.1.8--1.1.9.sql:DROP FUNCTION pgroonga.table_name;
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.table_name(indexName cstring)
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.table_name(indexName cstring)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.table_name(indexName cstring)
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.table_name(indexName cstring);
```

TODO:
* Test
* Resolve confrict