### PR TITLE
pgroonga: remove pgroonga.command(text, text[]) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.command(groongaCommand text, arguments text[]);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.command(groongaCommand text, arguments text[])
+    RETURNS text
+    AS 'MODULE_PATHNAME', 'pgroonga_command'
+    LANGUAGE C
+    VOLATILE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2638,14 +2638,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.command(groongaCommand text, arguments text[])
-			RETURNS text
-			AS 'MODULE_PATHNAME', 'pgroonga_command'
-			LANGUAGE C
-			VOLATILE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.query_expand(tableName cstring,
 						      termColumnName text,
 						      synonymsColumnName text,


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because pgroonga.command(text, text[]) is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.command" ./*
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.command(groongaCommand text)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.command(groongaCommand text, arguments text[])
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.command_escape_value(value text)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.command(groongaCommand text, arguments text[])
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.command_escape_value(value text)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.command(groongaCommand text, arguments text[])
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.command_escape_value(value text)
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.command(groongaCommand text)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.command(groongaCommand text)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.command(groongaCommand text, arguments text[])
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.command_escape_value(value text)
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.command(groongaCommand text);
./src/pgrn-command-escape-value.c: * pgroonga.command_escape_value(value text) : text
./src/pgroonga.c: * pgroonga.command(groongaCommand text) : text
./src/pgroonga.c: * pgroonga.command(groongaCommandName text, arguments text[]) : text
```

TODO:
* Test
* Resolve confrict