### PR TITLE
pgroonga: remove pgroonga.highlight_html(target text, keywords text[]) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.highlight_html(target text, keywords text[]);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.highlight_html(target text, keywords text[])
+    RETURNS text
+    AS 'MODULE_PATHNAME', 'pgroonga_highlight_html'
+    LANGUAGE C
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2665,14 +2665,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.highlight_html(target text, keywords text[])
-			RETURNS text
-			AS 'MODULE_PATHNAME', 'pgroonga_highlight_html'
-			LANGUAGE C
-			IMMUTABLE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.match_positions_byte(target text, keywords text[])
 			RETURNS integer[2][]
 			AS 'MODULE_PATHNAME', 'pgroonga_match_positions_byte'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because "pgroonga.highlight_html(target text, keywords text[])" is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.highlight_html" ./*
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.highlight_html(target text, keywords text[])
./data/pgroonga--1.0.6--1.0.7.sql:CREATE FUNCTION pgroonga.highlight_html(target text, keywords text[])
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.highlight_html(target text, keywords text[])
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.highlight_html(target text, keywords text[])
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.highlight_html(target text, keywords text[]);
./src/pgrn-highlight-html.c: * pgroonga.highlight_html(target text, keywords text[]) : text
./src/pgrn-highlight-html.c: * pgroonga.highlight_html(target text, keywords text[], indexName cstring) :
./src/pgrn-highlight-html.c: * pgroonga.highlight_html(target text[], keywords text[]) : text[]
./src/pgrn-highlight-html.c: * pgroonga.highlight_html(target text[], keywords text[], indexName cstring) :
```

TODO:
* Test
* Resolve confrict