### PR TITLE
pgroonga: remove pgroonga.flush(indexName cstring) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.flush(indexName cstring);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.flush(indexName cstring)
+    RETURNS bool
+    AS 'MODULE_PATHNAME', 'pgroonga_flush'
+    LANGUAGE C
+    VOLATILE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2697,14 +2697,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.flush(indexName cstring)
-			RETURNS bool
-			AS 'MODULE_PATHNAME', 'pgroonga_flush'
-			LANGUAGE C
-			VOLATILE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.command_escape_value(value text)
 			RETURNS text
 			AS 'MODULE_PATHNAME', 'pgroonga_command_escape_value'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because "pgroonga.flush(indexName cstring)" is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.flush" ./*
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.flush(indexName cstring)
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.flush(indexName cstring)
./data/pgroonga--1.1.0--1.1.1.sql:CREATE FUNCTION pgroonga.flush(indexName cstring)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.flush(indexName cstring)
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.flush(indexName cstring);
./src/pgrn-flush.c: * pgroonga.flush(indexName cstring) : boolean
```

TODO:
* Test
* Resolve confrict