### PR TITLE
pgroonga: remove pgroonga.query_escape(query text) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.query_escape(query text);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.query_escape(query text)
+    RETURNS text
+    AS 'MODULE_PATHNAME', 'pgroonga_query_escape'
+    LANGUAGE C
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2713,14 +2713,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.query_escape(query text)
-			RETURNS text
-			AS 'MODULE_PATHNAME', 'pgroonga_query_escape'
-			LANGUAGE C
-			IMMUTABLE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.escape(value text)
 			RETURNS text
 			AS 'MODULE_PATHNAME', 'pgroonga_escape_string'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because "pgroonga.query_escape(query text)" is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.query_escape" ./*
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.query_escape(query text)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.query_escape(query text)
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.query_escape(query text)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.query_escape(query text)
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.query_escape(query text);
```

TODO:
* Test
* Resolve confrict