### PR TITLE
pgroonga: remove pgroonga.escape(value text) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.escape(value text);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,11 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.escape(value text)
+    RETURNS text
+    AS 'MODULE_PATHNAME', 'pgroonga_escape_string'
+    LANGUAGE C
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2721,14 +2721,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.escape(value text)
-			RETURNS text
-			AS 'MODULE_PATHNAME', 'pgroonga_escape_string'
-			LANGUAGE C
-			IMMUTABLE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.escape(value text, special_characters text)
 			RETURNS text
 			AS 'MODULE_PATHNAME', 'pgroonga_escape_string'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

PGroonga's test don't remove in this PR.
Because "pgroonga.escape(value text)" is not used in PGroonga's tests as below.

```
% grep -r "pgroonga\.escape" ./*
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value text)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value text, special_characters text)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value boolean)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value int2)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value int4)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value int8)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value float4)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value float8)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value timestamp)
./data/pgroonga--3.2.5.sql:		CREATE FUNCTION pgroonga.escape(value timestamptz)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value text, special_characters text)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value boolean)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value int2)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value int4)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value int8)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value float4)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value float8)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value timestamp)
./data/pgroonga.sql:		CREATE FUNCTION pgroonga.escape(value timestamptz)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value text)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value text, special_characters text)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value boolean)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value int2)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value int4)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value int8)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value float4)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value float8)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value timestamp)
./data/pgroonga--1.1.8--1.1.9.sql:CREATE FUNCTION pgroonga.escape(value timestamptz)
./data/pgroonga--4.0.0--3.2.5.sql:CREATE FUNCTION pgroonga.escape(value text)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value text)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value text, special_characters text)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value boolean)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value int2)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value int4)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value int8)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value float4)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value float8)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value timestamp)
./data/pgroonga--4.0.0.sql:		CREATE FUNCTION pgroonga.escape(value timestamptz)
./data/pgroonga--3.2.5--4.0.0.sql:DROP FUNCTION pgroonga.escape(value text);
./src/pgrn-escape.c: * pgroonga.escape(value text, special_characters text = '"\') : text
./src/pgrn-escape.c: * pgroonga.escape(value boolean) : text
./src/pgrn-escape.c: * pgroonga.escape(value int2) : text
./src/pgrn-escape.c: * pgroonga.escape(value int4) : text
./src/pgrn-escape.c: * pgroonga.escape(value int8) : text
./src/pgrn-escape.c: * pgroonga.escape(value float4) : text
./src/pgrn-escape.c: * pgroonga.escape(value float8) : text
./src/pgrn-escape.c: * pgroonga.escape(value timestamptz) : text
```

TODO:
* Test
* Resolve confrict