### PR TITLE
pgroonga: remove pgroonga.escape(value float4) function

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -22,3 +22,5 @@ DROP OPERATOR FAMILY pgroonga.text_regexp_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_full_text_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_array_term_search_ops_v2 USING pgroonga;
 DROP OPERATOR FAMILY pgroonga.varchar_regexp_ops_v2 USING pgroonga;
+
+DROP FUNCTION pgroonga.escape(value float4);

--- a/data/pgroonga--4.0.0--3.2.5.sql
+++ b/data/pgroonga--4.0.0--3.2.5.sql
@@ -195,3 +195,12 @@ CREATE OPERATOR CLASS pgroonga.varchar_regexp_ops_v2 FOR TYPE varchar
     USING pgroonga AS
         OPERATOR 10 @~, -- For backward compatibility
         OPERATOR 22 &~;
+
+CREATE FUNCTION pgroonga.escape(value float4)
+    RETURNS text
+    AS 'MODULE_PATHNAME', 'pgroonga_escape_float8'
+    LANGUAGE C
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE;
+

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -2769,14 +2769,6 @@ BEGIN
 			STRICT
 			PARALLEL SAFE;
 
-		CREATE FUNCTION pgroonga.escape(value float4)
-			RETURNS text
-			AS 'MODULE_PATHNAME', 'pgroonga_escape_float8'
-			LANGUAGE C
-			IMMUTABLE
-			STRICT
-			PARALLEL SAFE;
-
 		CREATE FUNCTION pgroonga.escape(value float8)
 			RETURNS text
 			AS 'MODULE_PATHNAME', 'pgroonga_escape_float8'


### PR DESCRIPTION
GitHub: GH-647

This is part of the task of remove "pgroonga" schema. It's deprecated since PGroonga 2.
This is incompatible with PGroonga 3.x or earlier.

TODO:
* Test
* Resolve confrict