### PR TITLE
pgroonga: ensure dropping all pgroonga.snippet_html() definitions

### DIFF
--- a/data/pgroonga--3.2.5--4.0.0.sql
+++ b/data/pgroonga--3.2.5--4.0.0.sql
@@ -34,7 +34,8 @@ DROP FUNCTION pgroonga.query_expand(tableName cstring,
                                     termColumnName text,
                                     synonymsColumnName text,
                                     query text);
-DROP FUNCTION pgroonga.snippet_html(target text, keywords text[], width integer);
+DROP FUNCTION IF EXISTS pgroonga.snippet_html(target text, keywords text[]);
+DROP FUNCTION IF EXISTS pgroonga.snippet_html(target text, keywords text[], width integer);
 DROP FUNCTION pgroonga.highlight_html(target text, keywords text[]);
 DROP FUNCTION pgroonga.match_positions_byte(target text, keywords text[]);
 DROP FUNCTION pgroonga.match_positions_character(target text, keywords text[]);


### PR DESCRIPTION
https://chat.zulip.org/#narrow/channel/3-backend/topic/pgroonga/near/2089150

"pgroonga.snippet_html(target text, keywords text[], width integer)" may not exist depending on the environment.
Because we forgot to define "pgroonga.snippet_html(target text, keywords text[], width integer)" in upgrade SQL( https://github.com/pgroonga/pgroonga/blob/main/data/pgroonga--2.4.1--2.4.2.sql ) when we released PGroonga 2.4.2.
So, PGroonga may occur an error when we upgrade to PGroonga 4.0.0 from PGroonga installed as 2.4.1 or earlier initially.

We can avoid this error by using "DROP FUNCTION IF EXISTS" instead of "DROP FUNCTION" as below:

Here is the log when we upgrade to 4.0.0 from 2.4.1:

```
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE;'
ALTER EXTENSION pgroonga UPDATE;
ALTER EXTENSION
```

Here is the full upgrade log:

```
+ sudo apt install -y -V ./ubuntu/pool/jammy/universe/p/postgresql-13-pgdg-pgroonga/postgresql-13-pgdg-pgroonga_4.0.1-1_amd64.deb
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'postgresql-13-pgdg-pgroonga' instead of './ubuntu/pool/jammy/universe/p/postgresql-13-pgdg-pgroonga/postgresql-13-pgdg-pgroonga_4.0.1-1_amd64.deb'
The following packages will be upgraded:
   postgresql-13-pgdg-pgroonga (2.4.1-1 => 4.0.1-1)
1 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Need to get 0 B/738 kB of archives.
After this operation, 895 kB of additional disk space will be used.
Get:1 /root/ubuntu/pool/jammy/universe/p/postgresql-13-pgdg-pgroonga/postgresql-13-pgdg-pgroonga_4.0.1-1_amd64.deb postgresql-13-pgdg-pgroonga amd64 4.0.1-1 [738 kB]
(Reading database ... 21406 files and directories currently installed.)
Preparing to unpack .../postgresql-13-pgdg-pgroonga_4.0.1-1_amd64.deb ...
Unpacking postgresql-13-pgdg-pgroonga (4.0.1-1) over (2.4.1-1) ...
Setting up postgresql-13-pgdg-pgroonga (4.0.1-1) ...
Processing triggers for postgresql-common (267.pgdg22.04+1) ...
Building PostgreSQL dictionaries from installed myspell/hunspell packages...
Removing obsolete dictionary files:
N: Download is performed unsandboxed as root as file '/root/ubuntu/pool/jammy/universe/p/postgresql-13-pgdg-pgroonga/postgresql-13-pgdg-pgroonga_4.0.1-1_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
+ sudo -u postgres -H psql --echo-all -d pgroonga_test --command 'ALTER EXTENSION pgroonga UPDATE;'
could not change directory to "/root": Permission denied
ALTER EXTENSION pgroonga UPDATE;
ALTER EXTENSION
+ sudo -u postgres -H psql --echo-all -d pgroonga_test
could not change directory to "/root": Permission denied
SELECT unnest(pgroonga.snippet_html(
  'Groonga is a fast and accurate full text search engine based on ' ||
  'inverted index. One of the characteristics of Groonga is that a ' ||
  'newly registered document instantly appears in search results. ' ||
  'Also, Groonga allows updates without read locks. These characteristics ' ||
  'result in superior performance on real-time applications.' ||
  E'\n' ||
  E'\n' ||
  'Groonga is also a column-oriented database management system (DBMS). ' ||
  'Compared with well-known row-oriented systems, such as MySQL and ' ||
  'PostgreSQL, column-oriented systems are more suited for aggregate ' ||
  'queries. Due to this advantage, Groonga can cover weakness of ' ||
  'row-oriented systems.',
  ARRAY['Groonga']));
ERROR:  schema "pgroonga" does not exist
LINE 1: SELECT unnest(pgroonga.snippet_html(
                      ^
```

Reported by Tim Abbott. Thanks!!!