### PR TITLE
ci windows: use the latest version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,18 +22,18 @@ jobs:
       matrix:
         include:
           - postgresql-version-major: "13"
-            postgresql-version: "13.18-1"
+            postgresql-version: "13.19-1"
           - postgresql-version-major: "14"
-            postgresql-version: "14.15-1"
+            postgresql-version: "14.16-1"
           - postgresql-version-major: "15"
-            postgresql-version: "15.10-1"
+            postgresql-version: "15.11-1"
           - postgresql-version-major: "16"
-            postgresql-version: "16.6-1"
+            postgresql-version: "16.7-1"
           - postgresql-version-major: "17"
-            postgresql-version: "17.2-1"
+            postgresql-version: "17.3-1"
           - groonga-main: "yes"
             postgresql-version-major: "17"
-            postgresql-version: "17.2-1"
+            postgresql-version: "17.3-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"


### PR DESCRIPTION
PostgreSQL 17.3, 16.7, 15.11, 14.16, and 13.19 released at 2025-02-13.
See: https://www.postgresql.org/about/news/postgresql-173-167-1511-1416-and-1319-released-3015/ 