### PR TITLE
Optimaize to "match in" from "column %% keyword1 OR column %% keyword2 OR ..."

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,6 +42,13 @@ jobs:
           - label: PostgreSQL 17 with Groonga main
             groonga-main: "yes"
             postgresql-version: "17"
+          - label: PostgreSQL 18 snapshot
+            postgresql-unreleased: "yes"
+            postgresql-version: "18"
+          - label: PostgreSQL 18 with Groonga main
+            groonga-main: "yes"
+            postgresql-unreleased: "yes"
+            postgresql-version: "18"
     env:
       GROONGA_MAIN: ${{ matrix.groonga-main }}
       POSTGRESQL_UNRELEASED: ${{ matrix.postgresql-unreleased }}

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5391,8 +5391,8 @@ static bool
 PGrnSearchIsMatchIn(ScanKey key)
 {
 	return (key->sk_flags & SK_SEARCHARRAY) &&
-		   ((key->sk_strategy == PGrnMatchStrategyNumber)
-			|| (key->sk_strategy == PGrnMatchStrategyV2Number));
+		   ((key->sk_strategy == PGrnMatchStrategyNumber) ||
+			(key->sk_strategy == PGrnMatchStrategyV2Number));
 }
 
 static void

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -6129,10 +6129,11 @@ PGrnSearchBuildCondition(Relation index, ScanKey key, PGrnSearchData *data)
 	}
 	if (PGrnSearchIsMatchIn(key))
 	{
-		if (key->sk_strategy != PGrnMatchInStrategyV2Number)
-		{
-			key->sk_strategy = PGrnMatchInStrategyV2Number;
-		}
+		// PostgreSQL 18 optimaize to "column IN (keyword1, keyword2, ...)" from
+		// "column %% keyword1 OR column %% keyword2 OR ...".
+		// %% is match operator. So, we handle "column %% keyword1 OR column %%
+		// keyword2 OR ..." as "match in" operator.
+		key->sk_strategy = PGrnMatchInStrategyV2Number;
 	}
 
 	if (key->sk_strategy == PGrnMatchFTSConditionStrategyV2Number ||

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -53,7 +53,6 @@
 #include <nodes/nodeFuncs.h>
 #include <optimizer/optimizer.h>
 #include <pgstat.h>
-#include <stdbool.h>
 #include <storage/bufmgr.h>
 #include <storage/ipc.h>
 #include <storage/latch.h>


### PR DESCRIPTION
PostgreSQL 18 optimaize to "column IN (keyword1, keyword2, ...)" from "column %% keyword1 OR column %% keyword2 OR ...".
%% is match operator. So, we handle "column %% keyword1 OR column %% keyword2 OR ..." as "match in" operator.