### PR TITLE
ci windows: use the latest version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,18 +22,18 @@ jobs:
       matrix:
         include:
           - postgresql-version-major: "13"
-            postgresql-version: "13.19-1"
+            postgresql-version: "13.20-1"
           - postgresql-version-major: "14"
-            postgresql-version: "14.16-1"
+            postgresql-version: "14.17-1"
           - postgresql-version-major: "15"
-            postgresql-version: "15.11-1"
+            postgresql-version: "15.12-1"
           - postgresql-version-major: "16"
-            postgresql-version: "16.7-1"
+            postgresql-version: "16.8-1"
           - postgresql-version-major: "17"
-            postgresql-version: "17.3-1"
+            postgresql-version: "17.4-1"
           - groonga-main: "yes"
             postgresql-version-major: "17"
-            postgresql-version: "17.3-1"
+            postgresql-version: "17.4-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"


### PR DESCRIPTION
Because PostgreSQL 17.4, 16.8, 15.12, 14.17, and 13.20 released at 2025-02-20.
See: https://www.postgresql.org/about/news/postgresql-174-168-1512-1417-and-1320-released-3018/