### PR TITLE
ci: Add `--quiet` option to `incus launch`

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -177,7 +177,7 @@ jobs:
         run: |
           set -x
           sudo incus admin init --auto
-          sudo incus launch ${{ env.TEST_INCUS_IMAGE }} target
+          sudo incus launch --quiet ${{ env.TEST_INCUS_IMAGE }} target
           sudo incus config device add target host-rw disk source=$PWD path=/host-rw
           sudo incus config device add target host disk source=$PWD path=/host readonly=true
           # Ideally, we would use systemctl is-system-running --wait to ensure all services are fully operational.


### PR DESCRIPTION
It is easier to see the logs if there is no progress log.

```
$ incus --help | grep quiet
  -q, --quiet          Don't show progress information
```