### PR TITLE
ci: Work around permission error

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -186,6 +186,11 @@ jobs:
           # preventing DNS resolution errors when attempting to dnf install command.
           # ref: https://discuss.linuxcontainers.org/t/network-issue-with-almalinux-8-9-on-github-actions-using-incus/20046
           sleep 10
+
+          # Permission error.
+          # `mkdir: cannot create directory ‘/host-rw/logs’: Permission denied`
+          # To work around this, create `logs` directory on the host side with 777.
+          mkdir -m 777 logs
       - name: Test
         run: |
           sudo incus exec target \

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -20,7 +20,9 @@ function run_test() {
     echo "::group::Diff"
     cat regression.diffs
     echo "::endgroup::"
-    mkdir -p /host-rw/logs
+    if [ ! -d /host-rw/logs ]; then
+      mkdir -p /host-rw/logs
+    fi
     cp -a regression.diffs /host-rw/logs/
     cp -a ${data_dir}/log /host-rw/logs/postgresql || :
     mkdir -p /host-rw/logs/pgroonga/ || :

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -20,7 +20,9 @@ function run_test() {
     echo "::group::Diff"
     cat regression.diffs
     echo "::endgroup::"
-    mkdir -p /host-rw/logs
+    if [ ! -d /host-rw/logs ]; then
+      mkdir -p /host-rw/logs
+    fi
     cp -a regression.diffs /host-rw/logs/
     cp -a ${data_dir}/log /host-rw/logs/postgresql || :
     mkdir -p /host-rw/logs/pgroonga/ || :


### PR DESCRIPTION
Permission error.

```
mkdir: cannot create directory ‘/host-rw/logs’: Permission denied
```

To work around this, create `logs` directory on the host side with 777.