### PR TITLE
ci: Add `shift=true` option to `incus config device add`

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -178,7 +178,7 @@ jobs:
           set -x
           sudo incus admin init --auto
           sudo incus launch --quiet ${{ env.TEST_INCUS_IMAGE }} target
-          sudo incus config device add target host-rw disk source=$PWD path=/host-rw
+          sudo incus config device add target host-rw disk shift=true source=$PWD path=/host-rw
           sudo incus config device add target host disk source=$PWD path=/host readonly=true
           # Ideally, we would use systemctl is-system-running --wait to ensure all services are fully operational.
           # However, this option doesn't work in AlmaLinux 8 and results in an error.


### PR DESCRIPTION
Permission error:

```
mkdir: cannot create directory ‘/host-rw/logs’: Permission denied
```

Adding the `shift=true` option solves this.

shift:
Sets up a shifting overlay to translate the source UID/GID to match the instance (only for containers)
https://linuxcontainers.org/incus/docs/main/reference/devices_disk/