### PR TITLE
issue: add SQLs for confirming version of pgroonga extension and libgroonga

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,20 +29,32 @@ body:
     validations:
       required: true
   - type: textarea
-    id: environment
+    id: os-and-postgresql-version
     attributes:
-      label: Environment
-      description: Tell us your environment.
+      label: OS and PostgreSQL version
+      description: Tell us your OS version and PostgreSQL version.
       value: |
         - OS: [e.g. Ubuntu]
         - OS Version: [e.g. Ubuntu 24.04.2 LTS]
         - PostgreSQL Version: [e.g. 15.1]
-        - PGroonga Version: [e.g. 12.1.0]
-           - You can check the version by running:
-               SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
-        - libgroonga Version: [e.g.  8.0.1]
-           - You can check the version by running:
-               SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
+    validations:
+      required: true
+  - type: textarea
+    id: pgroonga-extension-version
+    attributes:
+      label: pgroonga extension version
+      description: Paste the result of the following SQL.
+      value: |
+        - SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
+    validations:
+      required: true
+  - type: textarea
+    id: libgroonga-version
+    attributes:
+      label: libgroonga version
+      description: Paste the result of the following SQL.
+      value: |
+        - SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: pgroonga-extension-version
+    id: pgroonga-version
     attributes:
       label: pgroonga extension version
       description: Paste the result of the following SQL.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
   - type: textarea
     id: groonga-version
     attributes:
-      label: libgroonga version
+      label: Groonga version
       description: Paste the result of the following SQL.
       value: |
         - SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: libgroonga-version
+    id: groonga-version
     attributes:
       label: libgroonga version
       description: Paste the result of the following SQL.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,9 +43,7 @@ body:
     id: pgroonga-version
     attributes:
       label: PGroonga version
-      description: Paste the result of the following SQL.
-      value: |
-        - SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
+      description: Paste the result of `SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';`
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,8 +38,9 @@ body:
         - OS Version: [e.g. Ubuntu 24.04.2 LTS]
         - PostgreSQL Version: [e.g. 15.1]
         - PGroonga Version: [e.g. 12.1.0]
+           - SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
         - libgroonga Version: [e.g.  8.0.1]
-           - https://pgroonga.github.io/reference/parameters/libgroonga-version.html
+           - SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,9 +50,7 @@ body:
     id: groonga-version
     attributes:
       label: Groonga version
-      description: Paste the result of the following SQL.
-      value: |
-        - SELECT pgroonga_command('status')::jsonb->1->'version' AS groonga_version;
+      description: Paste the result of `SELECT pgroonga_command('status')::jsonb->1->'version' AS groonga_version;`
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
       label: Groonga version
       description: Paste the result of the following SQL.
       value: |
-        - SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
+        - SELECT pgroonga_command('status')::jsonb->1->'version' AS groonga_version;
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,9 +38,11 @@ body:
         - OS Version: [e.g. Ubuntu 24.04.2 LTS]
         - PostgreSQL Version: [e.g. 15.1]
         - PGroonga Version: [e.g. 12.1.0]
-           - SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
+           - You can check the version by running:
+               SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
         - libgroonga Version: [e.g.  8.0.1]
-           - SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
+           - You can check the version by running:
+               SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
   - type: textarea
     id: pgroonga-version
     attributes:
-      label: pgroonga extension version
+      label: PGroonga version
       description: Paste the result of the following SQL.
       value: |
         - SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';


### PR DESCRIPTION
For example, we can show the libgroonga version as below.

We suggest use `pgroonga_command('status')` to confirm libgroonga version.
Because `pgroonga_command('status')` returns libgroonga version surely.

We can also use `SHOW pgroonga.libgroonga_version;` to confirm libgroonga version.
However, if we use `SHOW pgroonga.libgroonga_version;`, this command is failure when we execute this command at first since we connect database.

```sql
SELECT pgroonga_command('status')::jsonb->1->'version' AS libgroonga_version;
 libgroonga_version 
--------------------
 "15.0.3"
(1 row)
```

For example, we can show the version of pgroonga extension as below.

```sql
SELECT extversion FROM pg_catalog.pg_extension WHERE extname = 'pgroonga';
 extversion 
------------
 4.0.1
(1 row)
```