### PR TITLE
ci: windows: Add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` option to CMake

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -128,6 +128,7 @@ jobs:
             -S . ^
             -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
             -DCMAKE_INSTALL_PREFIX="..\pgsql" ^
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
             -DGRN_WITH_LZ4=bundled ^
             -DGRN_WITH_MECAB=bundled ^
             -DGRN_WITH_MESSAGE_PACK=bundled ^


### PR DESCRIPTION
CMake in CI environment fails with 4.0.0.

```
CMake Error at D:/a/pgroonga/build/_deps/zstd-src/build/cmake/CMakeLists.txt:10 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
```

We plan to migrate to Meson in the future.