### PR TITLE
ci: Fix incus device add error

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -178,7 +178,8 @@ jobs:
           set -x
           sudo incus admin init --auto
           sudo incus launch --quiet ${{ env.TEST_INCUS_IMAGE }} target
-          sudo incus config device add target host-rw disk shift=true source=$PWD path=/host-rw
+          mkdir -m 777 "${PWD}/host-rw"
+          sudo incus config device add target host-rw disk source=$PWD/host-rw path=/host-rw
           sudo incus config device add target host disk source=$PWD path=/host readonly=true
           # Ideally, we would use systemctl is-system-running --wait to ensure all services are fully operational.
           # However, this option doesn't work in AlmaLinux 8 and results in an error.
@@ -202,7 +203,7 @@ jobs:
           failure()
         with:
           name: ${{ matrix.package-id }}-logs
-          path: logs/
+          path: host-rw/logs/
 
   prepare-release:
     name: Prepare for release


### PR DESCRIPTION
With the latest GitHub Actions image, we get the following error:

```
Error: Failed to start device "host-rw": Required idmapping abilities not available
```

Same issue as this one:
https://discuss.linuxcontainers.org/t/error-failed-to-setup-device-mount-idmapping-abilities-are-required-but-arent-supported-on-system/19976

If the `shift=true` option is removed, this error will not occur.
However, when that option is removed, the GH-721 issue reoccurs.

That permission error could be avoided by creating the directory with mode=777.
So, remove the `shift=true` option and create the directory with mode=777.
