### PR TITLE
ci: Remove CMAKE_POLICY_VERSION_MINIMUM=3.5

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -128,7 +128,6 @@ jobs:
             -S . ^
             -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
             -DCMAKE_INSTALL_PREFIX="..\pgsql" ^
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
             -DGRN_WITH_LZ4=bundled ^
             -DGRN_WITH_MECAB=bundled ^
             -DGRN_WITH_MESSAGE_PACK=bundled ^


### PR DESCRIPTION
Related: GitHub GH-726

Already taken care of on Groonga.