### PR TITLE
ci package almalinux8/9: add/update Apache Arrow repository

### DIFF
--- a/packages/postgresql-13-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-13-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -8,6 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     epel-release && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \

--- a/packages/postgresql-14-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-14-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -8,6 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     epel-release && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \

--- a/packages/postgresql-15-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-15-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -8,6 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     epel-release && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \

--- a/packages/postgresql-15-pgdg-pgroonga/yum/almalinux-9/Dockerfile
+++ b/packages/postgresql-15-pgdg-pgroonga/yum/almalinux-9/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-    https://apache.jfrog.io/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   dnf groupinstall -y ${quiet} "Development Tools" && \

--- a/packages/postgresql-16-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-16-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -8,6 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     epel-release && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \

--- a/packages/postgresql-16-pgdg-pgroonga/yum/almalinux-9/Dockerfile
+++ b/packages/postgresql-16-pgdg-pgroonga/yum/almalinux-9/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-    https://apache.jfrog.io/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   dnf groupinstall -y ${quiet} "Development Tools" && \

--- a/packages/postgresql-17-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-17-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -8,6 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
     epel-release && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \

--- a/packages/postgresql-17-pgdg-pgroonga/yum/almalinux-9/Dockerfile
+++ b/packages/postgresql-17-pgdg-pgroonga/yum/almalinux-9/Dockerfile
@@ -8,7 +8,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf install -y ${quiet} \
     https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
-    https://apache.jfrog.io/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
+    https://packages.apache.org/artifactory/arrow/almalinux/9/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/9/groonga-release-latest.noarch.rpm && \
   sed -i'' -e 's/k$//g' /etc/yum.repos.d/pgdg-redhat-all.repo && \
   dnf groupinstall -y ${quiet} "Development Tools" && \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -52,12 +52,11 @@ case ${os} in
         ;;
       *)
         DNF="dnf --enablerepo=crb"
-        ${DNF} install -y \
-               https://apache.jfrog.io/artifactory/arrow/${os}/${major_version}/apache-arrow-release-latest.rpm
         ;;
     esac
 
     ${DNF} install -y \
+           https://packages.apache.org/artifactory/arrow/${os}/${major_version}/apache-arrow-release-latest.rpm \
            https://download.postgresql.org/pub/repos/yum/reporpms/EL-${major_version}-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
            https://packages.groonga.org/${os}/${major_version}/groonga-release-latest.noarch.rpm
     ;;


### PR DESCRIPTION
## Problem

The following error in build step is raised because Groonga APT repository doesn't serve arrow-devel-x.x.x package.

```
69.33 Error:
69.33  Problem: cannot install the best candidate for the job
69.33   - nothing provides arrow-devel >= 20.0.0 needed by groonga-devel-15.0.9-1.el8.x86_64 from groonga-almalinux
69.33 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

## Solution

We added/updated the official Apache Arrow repository.