### PR TITLE
custom-scan: Add information to plan

### DIFF
--- a/expected/custom-scan/debug.out
+++ b/expected/custom-scan/debug.out
@@ -1,17 +1,26 @@
 /* Temporary test to be used during implementation of a custom scan. */
 CREATE TABLE memos (content text);
 CREATE INDEX memos_content ON memos USING pgroonga (content);
-INSERT INTO memos VALUES ('PGroonga');
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine.');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga.');
 SET pgroonga.enable_custom_scan = on;
-EXPLAIN (COSTS OFF) SELECT * FROM memos;
-         QUERY PLAN         
-----------------------------
- Custom Scan (PGroongaScan)
+EXPLAIN (COSTS OFF)
+SELECT content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (PGroongaScan) on memos
+   Filter: (content &@~ 'PGroonga OR Groonga'::text)
    PGroongaScan: DEBUG
-(2 rows)
+(3 rows)
 
-SELECT * FROM memos;
---
+SELECT content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+ content 
+---------
 (0 rows)
 
 DROP TABLE memos;

--- a/sql/custom-scan/debug.sql
+++ b/sql/custom-scan/debug.sql
@@ -2,11 +2,19 @@
 
 CREATE TABLE memos (content text);
 CREATE INDEX memos_content ON memos USING pgroonga (content);
-INSERT INTO memos VALUES ('PGroonga');
+INSERT INTO memos VALUES ('PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES ('Groonga is fast full text search engine.');
+INSERT INTO memos VALUES ('PGroonga is a PostgreSQL extension that uses Groonga.');
 
 SET pgroonga.enable_custom_scan = on;
 
-EXPLAIN (COSTS OFF) SELECT * FROM memos;
-SELECT * FROM memos;
+EXPLAIN (COSTS OFF)
+SELECT content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+
+SELECT content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
 
 DROP TABLE memos;

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -121,9 +121,9 @@ PGrnPlanCustomPath(PlannerInfo *root,
 {
 	CustomScan *cscan = makeNode(CustomScan);
 	cscan->methods = &PGrnScanMethods;
-	cscan->scan.scanrelid = rel->relid;
-	cscan->scan.plan.targetlist = tlist;
 	cscan->scan.plan.qual = extract_actual_clauses(clauses, false);
+	cscan->scan.plan.targetlist = tlist;
+	cscan->scan.scanrelid = rel->relid;
 
 	return &(cscan->scan.plan);
 }


### PR DESCRIPTION
This commit is part of the work to implement a custom scan.

Set up the necessary information for scanning.

* scan.scanrelid
  * ID of the table to be scanned
* scan.plan.targetlist
  * Information about the tuple to be returned (e.g., column information)
* scan.plan.qual
  * Information on conditions such as `WHERE` clauses

Adding these will also increase the information displayed in `EXPLAIN`. We have also updated the test to check this.