### PR TITLE
custom-scan: Fetch and return data from Groonga resources

### DIFF
--- a/expected/custom-scan/debug.out
+++ b/expected/custom-scan/debug.out
@@ -19,8 +19,11 @@ SELECT content
 SELECT content
   FROM memos
  WHERE content &@~ 'PGroonga OR Groonga';
- content 
----------
-(0 rows)
+                        content                        
+-------------------------------------------------------
+ PostgreSQL is a RDBMS.
+ Groonga is fast full text search engine.
+ PGroonga is a PostgreSQL extension that uses Groonga.
+(3 rows)
 
 DROP TABLE memos;

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -218,7 +218,7 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 		return NULL;
 
 	id = grn_table_cursor_next(ctx, state->tableCursor);
-	if (!id)
+	if (id == GRN_ID_NIL)
 		return NULL;
 
 	{

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -260,7 +260,7 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 		grn_table_cursor_close(ctx, state->tableCursor);
 		state->tableCursor = NULL;
 	}
-	nTargetColumns = GRN_BULK_VSIZE(&(state->columns)) / sizeof(grn_obj *);
+	nTargetColumns = GRN_PTR_VECTOR_SIZE(&(state->columns));
 	for (unsigned int i = 0; i < nTargetColumns; i++)
 	{
 		grn_obj *column = GRN_PTR_VALUE_AT(&(state->columns), i);

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -148,6 +148,9 @@ PGrnCreateCustomScanState(CustomScan *cscan)
 
 	state->parent.methods = &PGrnExecuteMethods;
 
+	state->tableCursor = NULL;
+	GRN_PTR_INIT(&(state->columns), GRN_OBJ_VECTOR, GRN_ID_NIL);
+
 	return (Node *) &(state->parent);
 }
 
@@ -194,7 +197,6 @@ PGrnBeginCustomScan(CustomScanState *customScanState,
 	sourcesTable = PGrnLookupSourcesTable(index, ERROR);
 	RelationClose(index);
 
-	GRN_PTR_INIT(&(state->columns), GRN_OBJ_VECTOR, GRN_ID_NIL);
 	for (unsigned int i = 0; i < tupdesc->natts; i++)
 	{
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -231,6 +231,7 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 		{
 			Form_pg_attribute attr = &(slot->tts_tupleDescriptor->attrs[i]);
 			grn_obj *column = GRN_PTR_VALUE_AT(&(state->columns), i);
+			GRN_BULK_REWIND(&value);
 			grn_obj_get_value(ctx, column, id, &value);
 			slot->tts_values[i] = PGrnConvertToDatum(&value, attr->atttypid);
 			slot->tts_isnull[i] = false;

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -235,6 +235,10 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 			grn_obj_get_value(ctx, column, id, &(state->columnValue));
 			slot->tts_values[i] =
 				PGrnConvertToDatum(&(state->columnValue), attr->atttypid);
+			// todo
+			// If there are nullable columns, do not custom scan.
+			// See also
+			// https://github.com/pgroonga/pgroonga/pull/742#discussion_r2107937927
 			slot->tts_isnull[i] = false;
 		}
 		return ExecStoreVirtualTuple(slot);

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -255,7 +255,11 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 
 	ExecClearTuple(customScanState->ss.ps.ps_ResultTupleSlot);
 
-	grn_table_cursor_close(ctx, state->tableCursor);
+	if (state->tableCursor)
+	{
+		grn_table_cursor_close(ctx, state->tableCursor);
+		state->tableCursor = NULL;
+	}
 	nTargetColumns = GRN_BULK_VSIZE(&(state->columns)) / sizeof(grn_obj *);
 	for (unsigned int i = 0; i < nTargetColumns; i++)
 	{

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -270,8 +270,8 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 		grn_obj *column = GRN_PTR_VALUE_AT(&(state->columns), i);
 		grn_obj_unlink(ctx, column);
 	}
-	GRN_OBJ_FIN(ctx, &(state->columns));
 	GRN_OBJ_FIN(ctx, &(state->columnValue));
+	GRN_OBJ_FIN(ctx, &(state->columns));
 }
 
 static void


### PR DESCRIPTION
This commit is part of the work to implement a custom scan.

The first goal is to get the results of the following query as expected.
```sql
/* sql/custom-scan/debug.sql */
 SELECT content
   FROM memos
  WHERE content &@~ 'PGroonga OR Groonga';
```

This commit does not consider the conditions of the `WHERE` clause and fetches all data from Groonga's sources table.
The goal of the next PR is to filter by the conditions of the `WHERE` clause.