### PR TITLE
build: add Meson support for pgroonga_wal_applier module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,15 @@ pgroonga_database = shared_module('pgroonga_database',
   kwargs: pgrn_module_args,
 )
 
+pgroonga_wal_applier_sources = files(
+  'src/pgroonga-wal-applier.c',
+)
+
+pgroonga_wal_applier = shared_module('pgroonga_wal_applier',
+  pgroonga_wal_applier_sources,
+  kwargs: pgrn_module_args,
+)
+
 install_data('pgroonga_database.control',
   install_dir: pg_sharedir / 'extension',
 )


### PR DESCRIPTION
GitHub: GH-490

We added pgroonga_wal_applier module to the Meson build system like pgroonga_check did.
This module provides WAL application background worker functionality for PGroonga.