### PR TITLE
build: add Meson support for pgroonga_crash_safer module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,15 @@ pgroonga_wal_applier = shared_module('pgroonga_wal_applier',
   kwargs: pgrn_module_args,
 )
 
+pgroonga_crash_safer_sources = files(
+  'src/pgroonga-crash-safer.c',
+)
+
+pgroonga_crash_safer = shared_module('pgroonga_crash_safer',
+  pgroonga_crash_safer_sources,
+  kwargs: pgrn_module_args,
+)
+
 install_data('pgroonga_database.control',
   install_dir: pg_sharedir / 'extension',
 )


### PR DESCRIPTION
We added pgroonga_crash_safer module to the Meson build system like pgroonga_check did.
This module provides crash recovery management functionality.