### PR TITLE
build: add Meson support for pgroonga_standby_maintainer module

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,15 @@ pgroonga_crash_safer = shared_module('pgroonga_crash_safer',
   kwargs: pgrn_module_args,
 )
 
+pgroonga_standby_maintainer_sources = files(
+  'src/pgroonga-standby-maintainer.c',
+)
+
+pgroonga_standby_maintainer = shared_module('pgroonga_standby_maintainer',
+  pgroonga_standby_maintainer_sources,
+  kwargs: pgrn_module_args,
+)
+
 install_data('pgroonga_database.control',
   install_dir: pg_sharedir / 'extension',
 )


### PR DESCRIPTION
We added pgroonga-standby-maintainer module to the meson build system like other modules did.
This module provides standby server maintenance
functionality.