### PR TITLE
meson: improve xxHash vendor handling with WrapDB fallback

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -144,6 +144,23 @@ jobs:
         run: |
           cmake --install ..\build
 
+      - name: Install Meson and pkg-config
+        run: |
+          pip install meson ninja
+          choco install pkgconfiglite -y
+      - name: Configure PGroonga by Meson
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          set PKG_CONFIG_PATH=..\pgsql\lib\pkgconfig
+          meson setup ..\pgroonga.meson.build ^
+            -Dpg_config="..\pgsql\bin\pg_config.exe"
+      - name: Build PGroonga by Meson
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          meson compile -C ..\pgroonga.meson.build
+
       # Upload artifacts
       - name: Package
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -151,14 +151,12 @@ jobs:
       - name: Configure PGroonga by Meson
         shell: cmd
         run: |
-          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
           set PKG_CONFIG_PATH=..\pgsql\lib\pkgconfig
           meson setup ..\pgroonga.meson.build ^
             -Dpg_config="..\pgsql\bin\pg_config.exe"
       - name: Build PGroonga by Meson
         shell: cmd
         run: |
-          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
           meson compile -C ..\pgroonga.meson.build
 
       # Upload artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@
 /regression.*
 /results/
 /sql/vacuum/tablespace.sql
+/subprojects/xxHash-*
 /tmp/

--- a/meson.build
+++ b/meson.build
@@ -46,10 +46,8 @@ pgrn_dependencies = [postgresql, groonga]
 
 # MSVC includes math functions in its runtime libraries.
 if cc.get_id() != 'msvc'
-  libm = cc.find_library('m', required: false)
-  if libm.found()
-    pgrn_dependencies += libm
-  endif
+  libm = cc.find_library('m', required: true)
+  pgrn_dependencies += libm
 endif
 
 msgpack = dependency('msgpack-c', 'msgpack', required: get_option('message_pack'))

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,10 @@ if msgpack.found()
   pgrn_dependencies += pgrn_msgpack
 endif
 
-xxhash = dependency('libxxhash', required: get_option('xxhash'))
+xxhash = dependency('xxhash',
+  fallback: ['xxhash', 'xxhash_dep'],
+  required: get_option('xxhash'),
+)
 if xxhash.found()
   pgrn_dependencies += xxhash
 endif

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,6 @@ required_groonga_version = '14.0.0'
 
 groonga = dependency('groonga', version: '>= ' + required_groonga_version)
 cc = meson.get_compiler('c')
-libm = cc.find_library('m')
 
 pg_config_path = get_option('pg_config')
 if pg_config_path == ''
@@ -43,7 +42,12 @@ postgresql = declare_dependency(
   ],
 )
 
-pgrn_dependencies = [postgresql, groonga, libm]
+pgrn_dependencies = [postgresql, groonga]
+
+if host_machine.system() != 'windows'
+  libm = cc.find_library('m', required: false)
+  pgrn_dependencies += libm
+endif
 
 msgpack = dependency('msgpack-c', 'msgpack', required: get_option('message_pack'))
 if msgpack.found()

--- a/meson.build
+++ b/meson.build
@@ -34,9 +34,15 @@ if get_option('buildtype').startswith('debug')
   pgrn_c_args += ['-DPGROONGA_DEBUG=1']
 endif
 
+pg_cflags_sl = run_command(pg_config, '--cflags_sl', check: true).stdout().strip()
+if pg_cflags_sl == ''
+  pg_compile_args = []
+else
+  pg_compile_args = [pg_cflags_sl]
+endif
+
 postgresql = declare_dependency(
-  compile_args:
-    run_command(pg_config, '--cflags_sl', check: true).stdout().strip(),
+  compile_args: pg_compile_args,
   include_directories: [
     include_directories(pg_includedir_server, is_system: true),
   ],

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ if msgpack.found()
   pgrn_dependencies += pgrn_msgpack
 endif
 
-xxhash = dependency('xxhash',
+xxhash = dependency('libxxhash',
   fallback: ['xxhash', 'xxhash_dep'],
   required: get_option('xxhash'),
 )

--- a/meson.build
+++ b/meson.build
@@ -44,9 +44,12 @@ postgresql = declare_dependency(
 
 pgrn_dependencies = [postgresql, groonga]
 
-if host_machine.system() != 'windows'
+# MSVC includes math functions in its runtime libraries.
+if cc.get_id() != 'msvc'
   libm = cc.find_library('m', required: false)
-  pgrn_dependencies += libm
+  if libm.found()
+    pgrn_dependencies += libm
+  endif
 endif
 
 msgpack = dependency('msgpack-c', 'msgpack', required: get_option('message_pack'))

--- a/subprojects/xxhash.wrap
+++ b/subprojects/xxhash.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = xxHash-0.8.3
+source_url = https://github.com/Cyan4973/xxHash/archive/v0.8.3.tar.gz
+source_filename = xxHash-0.8.3.tar.gz
+source_hash = aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80
+patch_filename = xxhash_0.8.3-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/xxhash_0.8.3-1/get_patch
+patch_hash = 39c2418defa1d34cfe079c477b314b0a7a1bca657d91cdff4a05b8a7ed78aceb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/xxhash_0.8.3-1/xxHash-0.8.3.tar.gz
+wrapdb_version = 0.8.3-1
+
+[provide]
+libxxhash = xxhash_dep


### PR DESCRIPTION
GitHub: GH-490

We replaced xxHash vendor handling with Meson WrapDB support.

I set up subprojects/xxhash.wrap using the following command.

```console
$ meson wrap install xxhash
```