### PR TITLE
custom-scan: Include `commands/explain_format.h` for PostgreSQL 18 or higher

### DIFF
--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -1,5 +1,8 @@
 #include <postgres.h>
 
+#if PG_VERSION_NUM >= 180000
+#	include <commands/explain_format.h>
+#endif
 #include <nodes/extensible.h>
 #include <optimizer/pathnode.h>
 #include <optimizer/paths.h>


### PR DESCRIPTION
explain_format.* has been added and the relevant code has been moved.
https://github.com/postgres/postgres/commit/9173e8b604636633a8e3aca54bb56a437bffa718