### PR TITLE
Support index_beginscan for PostgreSQL 18 or higher

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -2,6 +2,8 @@
 
 #include <postgres.h>
 
+#include <access/genam.h>
+
 #ifdef _WIN32
 #	define PRId64 "I64d"
 #	define PRIu64 "I64u"
@@ -73,3 +75,21 @@ typedef Oid PGrnRelFileNumber;
 		((relkind) == RELKIND_RELATION || (relkind) == RELKIND_TOASTVALUE ||   \
 		 (relkind) == RELKIND_MATVIEW)
 #endif
+
+static inline IndexScanDesc
+pgrn_index_beginscan(Relation heapRelation,
+					 Relation indexRelation,
+					 Snapshot snapshot,
+					 int nKeys,
+					 int nOrderBys)
+{
+
+	return index_beginscan(heapRelation,
+						   indexRelation,
+						   snapshot,
+#if PG_VERSION_NUM >= 180000
+						   NULL,
+#endif
+						   nKeys,
+						   nOrderBys);
+}

--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -80,6 +80,11 @@ static inline IndexScanDesc
 pgrn_index_beginscan(Relation heapRelation,
 					 Relation indexRelation,
 					 Snapshot snapshot,
+#if PG_VERSION_NUM >= 180000
+					 IndexScanInstrumentation *instrument,
+#else
+					 void *instrument,
+#endif
 					 int nKeys,
 					 int nOrderBys)
 {
@@ -88,7 +93,7 @@ pgrn_index_beginscan(Relation heapRelation,
 						   indexRelation,
 						   snapshot,
 #if PG_VERSION_NUM >= 180000
-						   NULL,
+						   instrument,
 #endif
 						   nKeys,
 						   nOrderBys);

--- a/src/pgrn-query-expand.c
+++ b/src/pgrn-query-expand.c
@@ -559,8 +559,12 @@ pgroonga_query_expand(PG_FUNCTION_ARGS)
 		int nKeys = 1;
 		int nOrderBys = 0;
 		PGRN_TRACE_LOG("index_begin_scan");
-		currentData.scan = pgrn_index_beginscan(
-			currentData.table, index, currentData.snapshot, nKeys, nOrderBys);
+		currentData.scan = pgrn_index_beginscan(currentData.table,
+												index,
+												currentData.snapshot,
+												NULL,
+												nKeys,
+												nOrderBys);
 		currentData.slot = table_slot_create(currentData.table, NULL);
 	}
 	else

--- a/src/pgrn-query-expand.c
+++ b/src/pgrn-query-expand.c
@@ -559,7 +559,7 @@ pgroonga_query_expand(PG_FUNCTION_ARGS)
 		int nKeys = 1;
 		int nOrderBys = 0;
 		PGRN_TRACE_LOG("index_begin_scan");
-		currentData.scan = index_beginscan(
+		currentData.scan = pgrn_index_beginscan(
 			currentData.table, index, currentData.snapshot, nKeys, nOrderBys);
 		currentData.slot = table_slot_create(currentData.table, NULL);
 	}


### PR DESCRIPTION
Arguments have changed since PostgreSQL 18.
https://github.com/postgres/postgres/commit/0fbceae841cb5a31b13d3f284ac8fdd19822eceb

The added an argument is for getting scan statistics and other information.
First, we do not use that information and set the value to NULL, since the behavior will be the same as before. 