### PR TITLE
Use `pg_noreturn` instead of `pg_attribute_noreturn()`, in PostgreSQL 18

### DIFF
--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -44,6 +44,15 @@ static grn_ctx *ctx = NULL;
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
+
+#if PG_VERSION_NUM >= 180000
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_crash_safer_reset_position_one(Datum datum);
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_crash_safer_reindex_one(Datum datum);
+extern PGDLLEXPORT pg_noreturn void pgroonga_crash_safer_flush_one(Datum datum);
+extern PGDLLEXPORT pg_noreturn void pgroonga_crash_safer_main(Datum datum);
+#else
 extern PGDLLEXPORT void pgroonga_crash_safer_reset_position_one(Datum datum)
 	pg_attribute_noreturn();
 extern PGDLLEXPORT void pgroonga_crash_safer_reindex_one(Datum datum)
@@ -52,6 +61,7 @@ extern PGDLLEXPORT void pgroonga_crash_safer_flush_one(Datum datum)
 	pg_attribute_noreturn();
 extern PGDLLEXPORT void pgroonga_crash_safer_main(Datum datum)
 	pg_attribute_noreturn();
+#endif
 
 static volatile sig_atomic_t PGroongaCrashSaferGotSIGTERM = false;
 static volatile sig_atomic_t PGroongaCrashSaferGotSIGHUP = false;

--- a/src/pgroonga-standby-maintainer.c
+++ b/src/pgroonga-standby-maintainer.c
@@ -19,12 +19,22 @@
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
+
+#if PG_VERSION_NUM >= 180000
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_standby_maintainer_apply_wal(Datum datum);
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_standby_maintainer_maintain(Datum datum);
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_standby_maintainer_main(Datum datum);
+#else
 extern PGDLLEXPORT void pgroonga_standby_maintainer_apply_wal(Datum datum)
 	pg_attribute_noreturn();
 extern PGDLLEXPORT void pgroonga_standby_maintainer_maintain(Datum datum)
 	pg_attribute_noreturn();
 extern PGDLLEXPORT void pgroonga_standby_maintainer_main(Datum datum)
 	pg_attribute_noreturn();
+#endif
 
 #define TAG "pgroonga: standby-maintainer"
 

--- a/src/pgroonga-wal-applier.c
+++ b/src/pgroonga-wal-applier.c
@@ -18,10 +18,16 @@
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
+
+#if PG_VERSION_NUM >= 180000
+extern PGDLLEXPORT pg_noreturn void pgroonga_wal_applier_apply(Datum datum);
+extern PGDLLEXPORT pg_noreturn void pgroonga_wal_applier_main(Datum datum);
+#else
 extern PGDLLEXPORT void pgroonga_wal_applier_apply(Datum datum)
 	pg_attribute_noreturn();
 extern PGDLLEXPORT void pgroonga_wal_applier_main(Datum datum)
 	pg_attribute_noreturn();
+#endif
 
 #define TAG "pgroonga: wal-applier"
 


### PR DESCRIPTION
Changed to use `pg_noreturn`.
https://github.com/postgres/postgres/commit/3691edfab97187789b8a1cbb9dce4acf0ecd8f5a