### PR TITLE
Support for both `pg_attribute_noreturn()` and `pg_noreturn` environments

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -84,6 +84,12 @@ typedef Oid PGrnRelFileNumber;
 		((parallelScan)->ps_offset)
 #endif
 
+#if PG_VERSION_NUM >= 180000
+#	define pg_attribute_noreturn()
+#else
+#	define pg_noreturn
+#endif
+
 static inline IndexScanDesc
 pgrn_index_beginscan(Relation heapRelation,
 					 Relation indexRelation,

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -44,13 +44,13 @@ static grn_ctx *ctx = NULL;
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
-extern PGDLLEXPORT void pgroonga_crash_safer_reset_position_one(Datum datum)
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_crash_safer_reset_position_one(Datum datum) pg_attribute_noreturn();
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_crash_safer_reindex_one(Datum datum) pg_attribute_noreturn();
+extern PGDLLEXPORT pg_noreturn void pgroonga_crash_safer_flush_one(Datum datum)
 	pg_attribute_noreturn();
-extern PGDLLEXPORT void pgroonga_crash_safer_reindex_one(Datum datum)
-	pg_attribute_noreturn();
-extern PGDLLEXPORT void pgroonga_crash_safer_flush_one(Datum datum)
-	pg_attribute_noreturn();
-extern PGDLLEXPORT void pgroonga_crash_safer_main(Datum datum)
+extern PGDLLEXPORT pg_noreturn void pgroonga_crash_safer_main(Datum datum)
 	pg_attribute_noreturn();
 
 static volatile sig_atomic_t PGroongaCrashSaferGotSIGTERM = false;

--- a/src/pgroonga-standby-maintainer.c
+++ b/src/pgroonga-standby-maintainer.c
@@ -19,12 +19,12 @@
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
-extern PGDLLEXPORT void pgroonga_standby_maintainer_apply_wal(Datum datum)
-	pg_attribute_noreturn();
-extern PGDLLEXPORT void pgroonga_standby_maintainer_maintain(Datum datum)
-	pg_attribute_noreturn();
-extern PGDLLEXPORT void pgroonga_standby_maintainer_main(Datum datum)
-	pg_attribute_noreturn();
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_standby_maintainer_apply_wal(Datum datum) pg_attribute_noreturn();
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_standby_maintainer_maintain(Datum datum) pg_attribute_noreturn();
+extern PGDLLEXPORT pg_noreturn void
+pgroonga_standby_maintainer_main(Datum datum) pg_attribute_noreturn();
 
 #define TAG "pgroonga: standby-maintainer"
 

--- a/src/pgroonga-wal-applier.c
+++ b/src/pgroonga-wal-applier.c
@@ -18,9 +18,9 @@
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
-extern PGDLLEXPORT void pgroonga_wal_applier_apply(Datum datum)
+extern PGDLLEXPORT pg_noreturn void pgroonga_wal_applier_apply(Datum datum)
 	pg_attribute_noreturn();
-extern PGDLLEXPORT void pgroonga_wal_applier_main(Datum datum)
+extern PGDLLEXPORT pg_noreturn void pgroonga_wal_applier_main(Datum datum)
 	pg_attribute_noreturn();
 
 #define TAG "pgroonga: wal-applier"


### PR DESCRIPTION
`pg_attribute_noreturn()` has been changed to `pg_noreturn` in PostgreSQL18.
https://github.com/postgres/postgres/commit/3691edfab97187789b8a1cbb9dce4acf0ecd8f5a

From a maintainability standpoint, we will take the approach of defining dummies and putting #if in one place.