### PR TITLE
custom-scan: Filter by PGroonga operator

### DIFF
--- a/expected/custom-scan/debug.out
+++ b/expected/custom-scan/debug.out
@@ -21,9 +21,8 @@ SELECT content
  WHERE content &@~ 'PGroonga OR Groonga';
                         content                        
 -------------------------------------------------------
- PostgreSQL is a RDBMS.
- Groonga is fast full text search engine.
  PGroonga is a PostgreSQL extension that uses Groonga.
-(3 rows)
+ Groonga is fast full text search engine.
+(2 rows)
 
 DROP TABLE memos;

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -158,6 +158,7 @@ PGrnCreateCustomScanState(CustomScan *cscan)
 	state->tableCursor = NULL;
 	GRN_PTR_INIT(&(state->columns), GRN_OBJ_VECTOR, GRN_ID_NIL);
 	GRN_VOID_INIT(&(state->columnValue));
+	memset(&(state->searchData), 0, sizeof(state->searchData));
 	state->searched = NULL;
 
 	return (Node *) &(state->parent);
@@ -332,6 +333,7 @@ PGrnBeginCustomScan(CustomScanState *customScanState,
 	}
 
 	PGrnSearchDataFree(&(state->searchData));
+	memset(&(state->searchData), 0, sizeof(state->searchData));
 }
 
 static TupleTableSlot *
@@ -397,6 +399,12 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 	}
 	GRN_OBJ_FIN(ctx, &(state->columnValue));
 	GRN_OBJ_FIN(ctx, &(state->columns));
+
+	if (state->searchData.index != NULL)
+	{
+		PGrnSearchDataFree(&(state->searchData));
+		memset(&(state->searchData), 0, sizeof(state->searchData));
+	}
 	if (state->searched)
 	{
 		grn_obj_close(ctx, state->searched);

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -211,6 +211,7 @@ PGrnSearchBuildCustomScanConditions(CustomScanState *customScanState,
 									Relation index)
 {
 	PGrnScanState *state = (PGrnScanState *) customScanState;
+	const char *tag = "pgroonga: [custom-scan][build-conditions]";
 
 	List *quals = customScanState->ss.ps.plan->qual;
 	ListCell *cell;
@@ -224,11 +225,20 @@ PGrnSearchBuildCustomScanConditions(CustomScanState *customScanState,
 		Const *value;
 
 		if (!IsA(expr, OpExpr))
+		{
+			elog(DEBUG1, "%s node type is not OpExpr <%d>", tag, nodeTag(expr));
 			continue;
+		}
 
 		opexpr = (OpExpr *) expr;
 		if (list_length(opexpr->args) != 2)
+		{
+			elog(DEBUG1,
+				 "%s The number of arguments is not 2. <%d>",
+				 tag,
+				 list_length(opexpr->args));
 			continue;
+		}
 
 		left = linitial(opexpr->args);
 		right = lsecond(opexpr->args);
@@ -245,6 +255,11 @@ PGrnSearchBuildCustomScanConditions(CustomScanState *customScanState,
 		}
 		else
 		{
+			elog(DEBUG1,
+				 "%s The arguments are not a pair of Var and Const. <%d op %d>",
+				 tag,
+				 nodeTag(left),
+				 nodeTag(right));
 			continue;
 		}
 

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -400,7 +400,7 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 	GRN_OBJ_FIN(ctx, &(state->columnValue));
 	GRN_OBJ_FIN(ctx, &(state->columns));
 
-	if (state->searchData.index != NULL)
+	if (state->searchData.index)
 	{
 		PGrnSearchDataFree(&(state->searchData));
 		memset(&(state->searchData), 0, sizeof(state->searchData));

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -410,7 +410,6 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 		grn_obj_close(ctx, state->searched);
 		state->searched = NULL;
 	}
-	PGrnSearchDataFree(&(state->searchData));
 }
 
 static void

--- a/src/pgrn-search.h
+++ b/src/pgrn-search.h
@@ -27,3 +27,9 @@ void PGrnSearchBuildConditionBinaryOperation(PGrnSearchData *data,
 											 grn_obj *targetColumn,
 											 grn_obj *value,
 											 grn_operator operator);
+
+void
+PGrnSearchBuildCondition(Relation index, ScanKey key, PGrnSearchData *data);
+void
+PGrnSearchDataInit(PGrnSearchData *data, Relation index, grn_obj *sourcesTable);
+void PGrnSearchDataFree(PGrnSearchData *data);

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -6099,7 +6099,7 @@ PGrnSearchBuildConditionBinaryOperation(PGrnSearchData *data,
 	PGrnExprAppendOp(data->expression, operator, 2, tag, NULL);
 }
 
-static void
+void
 PGrnSearchBuildCondition(Relation index, ScanKey key, PGrnSearchData *data)
 {
 	const char *tag = "[build-condition]";
@@ -6508,7 +6508,7 @@ PGrnSearchBuildConditions(IndexScanDesc scan,
 	}
 }
 
-static void
+void
 PGrnSearchDataInit(PGrnSearchData *data, Relation index, grn_obj *sourcesTable)
 {
 	data->index = index;
@@ -6523,7 +6523,7 @@ PGrnSearchDataInit(PGrnSearchData *data, Relation index, grn_obj *sourcesTable)
 	data->nExpressions = 0;
 }
 
-static void
+void
 PGrnSearchDataFree(PGrnSearchData *data)
 {
 	unsigned int i;

--- a/src/pgroonga.h
+++ b/src/pgroonga.h
@@ -6,11 +6,13 @@
 
 #include <postgres.h>
 
+#include <access/skey.h>
 #include <fmgr.h>
 #include <utils/rel.h>
 
 #include "pgrn-compatible.h"
 #include "pgrn-constant.h"
+#include "pgrn-search.h"
 
 /* Used for pgroonga.so not other pgroonga_*.so. */
 #define PGRN_MODULE_PGROONGA
@@ -119,3 +121,9 @@ void PGrnEnsureDatabase(void);
 void PGrnRemoveUnusedTables(void);
 bool PGrnIndexIsPGroonga(Relation index);
 Datum PGrnConvertToDatum(grn_obj *value, Oid typeID);
+
+void
+PGrnSearchBuildCondition(Relation index, ScanKey key, PGrnSearchData *data);
+void
+PGrnSearchDataInit(PGrnSearchData *data, Relation index, grn_obj *sourcesTable);
+void PGrnSearchDataFree(PGrnSearchData *data);

--- a/src/pgroonga.h
+++ b/src/pgroonga.h
@@ -121,9 +121,3 @@ void PGrnEnsureDatabase(void);
 void PGrnRemoveUnusedTables(void);
 bool PGrnIndexIsPGroonga(Relation index);
 Datum PGrnConvertToDatum(grn_obj *value, Oid typeID);
-
-void
-PGrnSearchBuildCondition(Relation index, ScanKey key, PGrnSearchData *data);
-void
-PGrnSearchDataInit(PGrnSearchData *data, Relation index, grn_obj *sourcesTable);
-void PGrnSearchDataFree(PGrnSearchData *data);

--- a/src/pgroonga.h
+++ b/src/pgroonga.h
@@ -6,7 +6,6 @@
 
 #include <postgres.h>
 
-#include <access/skey.h>
 #include <fmgr.h>
 #include <utils/rel.h>
 


### PR DESCRIPTION
This commit is part of the work to implement a custom scan.

The first goal is to get the results of the following query as expected.

```sql
/* sql/custom-scan/debug.sql */
 SELECT content
   FROM memos
  WHERE content &@~ 'PGroonga OR Groonga';
```

Use PGrnSearchBuildCondition() to filter.