### PR TITLE
ci macos: add Meson build support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,7 +88,7 @@ jobs:
           meson compile -C ../pgroonga.build
       - name: Install PGroonga
         run: |
-          sudo meson install -C ../pgroonga.build
+          meson install -C ../pgroonga.build
       - name: Run regression test
         run: |
           # TODO: Remove me when groonga formula enables libstemmer

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,20 +77,27 @@ jobs:
           brew services start postgresql@${{ matrix.postgresql-version }}
           echo $(brew --prefix postgresql@${{ matrix.postgresql-version }})/bin >> \
             ${GITHUB_PATH}
+      - name: Configure PGroonga
+        run: |
+          meson setup \
+            --buildtype=debug \
+            -Dpg_config=$(brew --prefix postgresql@${{ matrix.postgresql-version }})/bin/pg_config \
+            ../pgroonga.build
+      - name: Build PGroonga
+        run: |
+          meson compile -C ../pgroonga.build
+      - name: Install PGroonga
+        run: |
+          sudo meson install -C ../pgroonga.build
       - name: Run regression test
         run: |
           # TODO: Remove me when groonga formula enables libstemmer
           rm sql/full-text-search/text/options/token-filters/custom.sql
-          PG_CONFIG=$(brew --prefix postgresql@${{ matrix.postgresql-version }})/bin/pg_config \
-            test/run-sql-test.sh
-        env:
-          HAVE_XXHASH: "1"
-          MSGPACK_PACKAGE_NAME: "msgpack-c"
-          SUPPRESS_LOG: "no"
+          meson test -C ../pgroonga.build -v
       - name: Show diff
         if: failure()
         run: |
-          cat regression.diffs
+          cat ../pgroonga.build/regression.diffs
       - name: Show pgroonga.log
         if: failure()
         run: |

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
 brew "groonga"
+brew "meson"
+brew "ninja"
 brew "postgresql"
 brew "xxhash"

--- a/meson.build
+++ b/meson.build
@@ -35,9 +35,15 @@ if get_option('buildtype').startswith('debug')
   pgrn_c_args += ['-DPGROONGA_DEBUG=1']
 endif
 
+# Note: Meson's split() is NOT shell-compatible
+# It splits only on whitespace and doesn't understand shell quoting
+# For example: 'a "b c" d' becomes ['a', '"b', 'c"', 'd'] instead of ['a', 'b c', 'd']
+# This works for most PostgreSQL flags but may break with quoted paths containing spaces
+pg_cppflags = run_command(pg_config, '--cppflags', check: true).stdout().strip().split()
+pg_cflags_sl = run_command(pg_config, '--cflags_sl', check: true).stdout().strip().split()
+
 postgresql = declare_dependency(
-  compile_args:
-    run_command(pg_config, '--cflags_sl', check: true).stdout().strip(),
+  compile_args: pg_cppflags + pg_cflags_sl,
   include_directories: [
     include_directories(pg_includedir_server, is_system: true),
   ],
@@ -59,11 +65,18 @@ if xxhash.found()
   pgrn_dependencies += xxhash
 endif
 
+name_suffix = 'so'
+if host_machine.system() == 'darwin' and \
+   pg_config.version().version_compare('>= 16')
+  name_suffix = 'dylib'
+endif
+
 pgrn_module_args = {
   'c_args': pgrn_c_args,
   'dependencies': pgrn_dependencies,
   'include_directories': [include_directories('src')],
   'name_prefix': '',
+  'name_suffix': name_suffix,
   'install': true,
   'install_dir': pg_pkglibdir,
 }

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ endif
 # It splits only on whitespace and doesn't understand shell quoting.
 # For example: 'a "b c" d' becomes ['a', '"b', 'c"', 'd'] instead of ['a', 'b c', 'd'].
 # This works for most PostgreSQL flags but may break with quoted paths containing spaces.
+# Related upstream issue: https://github.com/mesonbuild/meson/issues/15000
 pg_cppflags = run_command(pg_config, '--cppflags', check: true).stdout().strip().split()
 pg_cflags_sl = run_command(pg_config, '--cflags_sl', check: true).stdout().strip().split()
 

--- a/meson.build
+++ b/meson.build
@@ -35,10 +35,10 @@ if get_option('buildtype').startswith('debug')
   pgrn_c_args += ['-DPGROONGA_DEBUG=1']
 endif
 
-# Note: Meson's split() is NOT shell-compatible
-# It splits only on whitespace and doesn't understand shell quoting
-# For example: 'a "b c" d' becomes ['a', '"b', 'c"', 'd'] instead of ['a', 'b c', 'd']
-# This works for most PostgreSQL flags but may break with quoted paths containing spaces
+# Note: Meson's split() is NOT shell-compatible.
+# It splits only on whitespace and doesn't understand shell quoting.
+# For example: 'a "b c" d' becomes ['a', '"b', 'c"', 'd'] instead of ['a', 'b c', 'd'].
+# This works for most PostgreSQL flags but may break with quoted paths containing spaces.
 pg_cppflags = run_command(pg_config, '--cppflags', check: true).stdout().strip().split()
 pg_cflags_sl = run_command(pg_config, '--cflags_sl', check: true).stdout().strip().split()
 


### PR DESCRIPTION
GitHub: GH-490

This PR enables building PGroonga with Meson on macOS
by addressing platform-specific compilation and module
loading requirements:
- Use PostgreSQL's complete compile flags
  (`--cppflags` and `--cflags_sl`) to include the system
  dependencies like gettext for libintl.h
- Handle module extension differences based on
  PostgreSQL version:
  - PostgreSQL < 16: use .so extension
  - PostgreSQL >= 16: use .dylib extension