### PR TITLE
Add support for amtranslate routines for PostgreSQL 18 or higher

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -35,6 +35,10 @@
 #	define PGRN_SUPPORT_PARALLEL_INDEX_BUILD
 #endif
 
+#if PG_VERSION_NUM >= 180000
+#	define PGRN_SUPPORT_AMTRANSLATE_ROUTINE
+#endif
+
 #if PG_VERSION_NUM >= 160000
 #	define PGRN_RELATION_GET_LOCATOR(relation) ((relation)->rd_locator)
 #	define PGRN_RELATION_GET_LOCATOR_NUMBER(relation)                         \

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -8842,6 +8842,7 @@ PGrnParallelScanAcquire(IndexScanDesc scan)
 	return acquired;
 }
 
+#ifdef PGRN_SUPPORT_AMTRANSLATE_ROUTINE
 static CompareType
 pgroonga_translatestrategy(StrategyNumber strategy, Oid opfamily)
 {
@@ -8881,6 +8882,7 @@ pgroonga_translatecmptype(CompareType cmptype, Oid opfamily)
 		return InvalidStrategy;
 	}
 }
+#endif
 
 Datum
 pgroonga_handler(PG_FUNCTION_ARGS)

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -8842,6 +8842,46 @@ PGrnParallelScanAcquire(IndexScanDesc scan)
 	return acquired;
 }
 
+static CompareType
+pgroonga_translatestrategy(StrategyNumber strategy, Oid opfamily)
+{
+	switch (strategy)
+	{
+	case PGrnLessStrategyNumber:
+		return COMPARE_LT;
+	case PGrnLessEqualStrategyNumber:
+		return COMPARE_LE;
+	case PGrnEqualStrategyNumber:
+		return COMPARE_EQ;
+	case PGrnGreaterStrategyNumber:
+		return COMPARE_GT;
+	case PGrnGreaterEqualStrategyNumber:
+		return COMPARE_GE;
+	default:
+		return COMPARE_INVALID;
+	}
+}
+
+static StrategyNumber
+pgroonga_translatecmptype(CompareType cmptype, Oid opfamily)
+{
+	switch (cmptype)
+	{
+	case COMPARE_LT:
+		return PGrnLessStrategyNumber;
+	case COMPARE_LE:
+		return PGrnLessEqualStrategyNumber;
+	case COMPARE_EQ:
+		return PGrnEqualStrategyNumber;
+	case COMPARE_GT:
+		return PGrnGreaterStrategyNumber;
+	case COMPARE_GE:
+		return PGrnGreaterEqualStrategyNumber;
+	default:
+		return InvalidStrategy;
+	}
+}
+
 Datum
 pgroonga_handler(PG_FUNCTION_ARGS)
 {
@@ -8889,6 +8929,10 @@ pgroonga_handler(PG_FUNCTION_ARGS)
 	routine->amestimateparallelscan = pgroonga_estimateparallelscan;
 	routine->aminitparallelscan = pgroonga_initparallelscan;
 	routine->amparallelrescan = pgroonga_parallelrescan;
+#ifdef PGRN_SUPPORT_AMTRANSLATE_ROUTINE
+	routine->amtranslatecmptype = pgroonga_translatecmptype;
+	routine->amtranslatestrategy = pgroonga_translatestrategy;
+#endif
 
 	PG_RETURN_POINTER(routine);
 }


### PR DESCRIPTION
We can implements amtranslatecmptype and amtranslatestrategy in index access method by https://github.com/postgres/postgres/commit/a8025f544854ad8b865c6b4509030ee84aa8f4a0.
If we don't implement them explicitly, PostgreSQL doesn't be regarded as ordered index.

PGroonga can return ordered result. So, we need to implement amtranslatecmptype and amtranslatestrategy.