### PR TITLE
packages postgresql-14: add support for Debian 13

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -81,6 +81,8 @@ jobs:
           - postgresql-15-pgroonga-debian-bookworm-arm64
           - postgresql-14-pgdg-pgroonga-debian-bookworm
           - postgresql-14-pgdg-pgroonga-debian-bookworm-arm64
+          - postgresql-14-pgdg-pgroonga-debian-trixie
+          - postgresql-14-pgdg-pgroonga-debian-trixie-arm64
           - postgresql-14-pgdg-pgroonga-ubuntu-jammy
           - postgresql-14-pgdg-pgroonga-ubuntu-jammy-arm64
           - postgresql-14-pgdg-pgroonga-ubuntu-noble

--- a/packages/postgresql-14-pgdg-pgroonga/Rakefile
+++ b/packages/postgresql-14-pgdg-pgroonga/Rakefile
@@ -9,6 +9,8 @@ class PostgreSQL14PGDGPGroongaPackageTask < VersionedPGroongaPackageTask
     [
       "debian-bookworm",
       "debian-bookworm-arm64",
+      "debian-trixie",
+      "debian-trixie-arm64",
       "ubuntu-jammy",
       "ubuntu-jammy-arm64",
       "ubuntu-noble",

--- a/packages/postgresql-14-pgdg-pgroonga/apt/debian-trixie-arm64/from
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/debian-trixie-arm64/from
@@ -1,0 +1,1 @@
+--platform=linux/arm64 arm64v8/debian:trixie

--- a/packages/postgresql-14-pgdg-pgroonga/apt/debian-trixie/Dockerfile
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/debian-trixie/Dockerfile
@@ -12,7 +12,7 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} lsb-release wget && \
-  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \

--- a/packages/postgresql-14-pgdg-pgroonga/apt/debian-trixie/Dockerfile
+++ b/packages/postgresql-14-pgdg-pgroonga/apt/debian-trixie/Dockerfile
@@ -1,0 +1,39 @@
+ARG FROM=debian:trixie
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+ARG POSTGRESQL_VERSION
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} lsb-release wget && \
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  wget https://packages.groonga.org/debian/groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm groonga-apt-source-latest-$(lsb_release --codename --short).deb && \
+  wget -O /usr/share/keyrings/pgdg.asc https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
+  (echo "Types: deb"; \
+   echo "URIs: http://apt.postgresql.org/pub/repos/apt"; \
+   echo "Suites: $(lsb_release --codename --short)-pgdg"; \
+   echo "Components: main"; \
+   echo "Signed-By: /usr/share/keyrings/pgdg.asc") | \
+    tee /etc/apt/sources.list.d/pgdg.sources && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    ccache \
+    debhelper \
+    devscripts \
+    libgroonga-dev \
+    libmsgpack-dev \
+    libxxhash-dev \
+    pkg-config \
+    postgresql-server-dev-${POSTGRESQL_VERSION} && \
+  apt clean

--- a/packages/postgresql-14-pgdg-pgroonga/debian/rules
+++ b/packages/postgresql-14-pgdg-pgroonga/debian/rules
@@ -10,7 +10,11 @@ export DH_OPTIONS
 	dh $@
 
 override_dh_auto_build:
-	dh_auto_build -- HAVE_MSGPACK=1
+	if [ "$$(lsb_release --codename --short)" = "trixie" ]; then		\
+		dh_auto_build -- HAVE_MSGPACK=1 MSGPACK_PACKAGE_NAME=msgpack-c;	\
+	else	\
+		dh_auto_build -- HAVE_MSGPACK=1;	\
+	fi
 
 # disable 'make check'.
 override_dh_auto_test:

--- a/packages/postgresql-14-pgdg-pgroonga/debian/rules
+++ b/packages/postgresql-14-pgdg-pgroonga/debian/rules
@@ -10,10 +10,10 @@ export DH_OPTIONS
 	dh $@
 
 override_dh_auto_build:
-	if [ "$$(lsb_release --codename --short)" = "trixie" ]; then		\
-		dh_auto_build -- HAVE_MSGPACK=1 MSGPACK_PACKAGE_NAME=msgpack-c;	\
-	else									\
+	if [ "$$(lsb_release --codename --short)" = "bookworm" ]; then		\
 		dh_auto_build -- HAVE_MSGPACK=1;				\
+	else									\
+		dh_auto_build -- HAVE_MSGPACK=1 MSGPACK_PACKAGE_NAME=msgpack-c;	\
 	fi
 
 # disable 'make check'.

--- a/packages/postgresql-14-pgdg-pgroonga/debian/rules
+++ b/packages/postgresql-14-pgdg-pgroonga/debian/rules
@@ -10,12 +10,14 @@ export DH_OPTIONS
 	dh $@
 
 override_dh_auto_build:
-	# We can remove this condition after Debian 12 (bookworm) is EOL.
-	if [ "$$(lsb_release --codename --short)" = "bookworm" ]; then		\
+	case "$$(lsb_release --codename --short)" in				\
+	  bookworm|jammy|noble)							\
 		dh_auto_build -- HAVE_MSGPACK=1;				\
-	else									\
+		;;								\
+	  *)									\
 		dh_auto_build -- HAVE_MSGPACK=1 MSGPACK_PACKAGE_NAME=msgpack-c;	\
-	fi
+		;;								\
+	esac
 
 # disable 'make check'.
 override_dh_auto_test:

--- a/packages/postgresql-14-pgdg-pgroonga/debian/rules
+++ b/packages/postgresql-14-pgdg-pgroonga/debian/rules
@@ -10,7 +10,7 @@ export DH_OPTIONS
 	dh $@
 
 override_dh_auto_build:
-	# We can remove this condition after Debian 12 (bookworm) is EOLed.
+	# We can remove this condition after Debian 12 (bookworm) is EOL.
 	if [ "$$(lsb_release --codename --short)" = "bookworm" ]; then		\
 		dh_auto_build -- HAVE_MSGPACK=1;				\
 	else									\

--- a/packages/postgresql-14-pgdg-pgroonga/debian/rules
+++ b/packages/postgresql-14-pgdg-pgroonga/debian/rules
@@ -12,8 +12,8 @@ export DH_OPTIONS
 override_dh_auto_build:
 	if [ "$$(lsb_release --codename --short)" = "trixie" ]; then		\
 		dh_auto_build -- HAVE_MSGPACK=1 MSGPACK_PACKAGE_NAME=msgpack-c;	\
-	else	\
-		dh_auto_build -- HAVE_MSGPACK=1;	\
+	else									\
+		dh_auto_build -- HAVE_MSGPACK=1;				\
 	fi
 
 # disable 'make check'.

--- a/packages/postgresql-14-pgdg-pgroonga/debian/rules
+++ b/packages/postgresql-14-pgdg-pgroonga/debian/rules
@@ -10,6 +10,7 @@ export DH_OPTIONS
 	dh $@
 
 override_dh_auto_build:
+	# We can remove this condition after Debian 12 (bookworm) is EOLed.
 	if [ "$$(lsb_release --codename --short)" = "bookworm" ]; then		\
 		dh_auto_build -- HAVE_MSGPACK=1;				\
 	else									\


### PR DESCRIPTION
This commit is part of the work to implement GH-779.

The package name of MessagePack change to msgpack-c from msgpack since Debian 13 (trixie).