### PR TITLE
custom-scan: Remove outputting debug to explain

### DIFF
--- a/expected/custom-scan/debug.out
+++ b/expected/custom-scan/debug.out
@@ -13,8 +13,7 @@ SELECT content
 -----------------------------------------------------
  Custom Scan (PGroongaScan) on memos
    Filter: (content &@~ 'PGroonga OR Groonga'::text)
-   PGroongaScan: DEBUG
-(3 rows)
+(2 rows)
 
 SELECT content
   FROM memos

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -375,7 +375,7 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 static void
 PGrnExplainCustomScan(CustomScanState *node, List *ancestors, ExplainState *es)
 {
-	ExplainPropertyText("PGroongaScan", "DEBUG", es);
+	// todo Add the necessary information when we find it.
 }
 
 static void


### PR DESCRIPTION
We'll add any extra information if needed.
Since we'll be adding more tests, the debug output just gets in the way, so we'll remove it.