### PR TITLE
Use .editorconfig instead of .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,8 +1,0 @@
-((c-mode . ((c-file-style . "bsd")
-            (c-basic-offset . 4)
-            (tab-width . 4)
-            (indent-tabs-mode . t)
-            (show-trailing-whitespace . t)))
- (sh-mode . ((indent-tabs-mode . nil)
-             (sh-indentation   . 2)
-             (sh-basic-offset  . 2))))

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+spelling_language = en
+trim_trailing_whitespace = true
+
+[*.{c,h}]
+indent_size = 4
+indent_style = tab
+
+[*.sh]
+indent_size = 2
+indent_style = space
+
+[rules]
+indent_size = 8
+indent_style = tab

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,7 @@ repos:
     rev: "v1.8.2"
     hooks:
       - id: meson-fmt
+        types:
+          - meson
 
 exclude: "^vendor/.*"


### PR DESCRIPTION
GitHub's PR view may use 8 spaces for a tab in `debian/rules` by this.