### PR TITLE
postgresql-19: use `Node *' instead of `fmNodePtr`

### DIFF
--- a/src/pgrn-pg.c
+++ b/src/pgrn-pg.c
@@ -296,7 +296,7 @@ PGrnPGHavePreparedTransaction(void)
 		econtext = CreateExprContext(estate);
 		fmgr_info(F_PG_PREPARED_XACT, &flinfo);
 		InitFunctionCallInfoData(
-			*fcinfo, &flinfo, 0, InvalidOid, NULL, (fmNodePtr) &rsinfo);
+			*fcinfo, &flinfo, 0, InvalidOid, NULL, (Node *) &rsinfo);
 		rsinfo.type = T_ReturnSetInfo;
 		rsinfo.econtext = econtext;
 		rsinfo.expectedDesc = NULL;


### PR DESCRIPTION
`fmNodePtr` was removed:
https://github.com/postgres/postgres/commit/4bd91912987d794c48dd4ba4c337906bd23759be

https://github.com/pgroonga/pgroonga/actions/runs/17998815903/job/51203377015#step:8:43

```text
In file included from ../pgroonga/src/pgroonga.h:9,
                 from ../pgroonga/src/pgrn-pg.c:1:
../pgroonga/src/pgrn-pg.c: In function ‘PGrnPGHavePreparedTransaction’:
../pgroonga/src/pgrn-pg.c:299:65: error: ‘fmNodePtr’ undeclared (first use in this function)
  299 |                         *fcinfo, &flinfo, 0, InvalidOid, NULL, (fmNodePtr) &rsinfo);
      |                                                                 ^~~~~~~~~
```