### PR TITLE
postgresql-19: cast `Datum` to `Pointer` for `VARDATA_ANY()`/`VARSIZE_ANY_EXHDR`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,13 +120,9 @@ jobs:
         env:
           PG_CONFIG: "/usr/lib/postgresql/${{ matrix.postgresql-version }}/bin/pg_config"
       - name: Build PGroonga
-        # TODO: Remove this when we're PostgreSQL 19 ready
-        continue-on-error: ${{ matrix.postgresql-version == '19' && true || false }}
         run: |
           meson compile -C ../pgroonga.build
       - name: Install PGroonga
-        # TODO: Remove this when we're PostgreSQL 19 ready
-        continue-on-error: ${{ matrix.postgresql-version == '19' && true || false }}
         run: |
           sudo meson install -C ../pgroonga.build
       - name: Run regression test
@@ -141,13 +137,13 @@ jobs:
           cat ../pgroonga.build/regression.diffs || :
       - name: Show pgroonga.log
         # TODO: Remove "matrix.postgresql-version == '19' ||" when we're PostgreSQL 19 ready
-        if: matrix.postgresql-unreleased == '19' || failure()
+        if: matrix.postgresql-version == '19' || failure()
         run: |
           sudo cat \
             /var/lib/postgresql/${{ matrix.postgresql-version }}/main/pgroonga.log || :
       - name: Show pgroonga.log of parsed backtrace
         # TODO: Remove "matrix.postgresql-version == '19' ||" when we're PostgreSQL 19 ready
-        if: matrix.postgresql-unreleased == '19' || failure()
+        if: matrix.postgresql-version == '19' || failure()
         run: |
           wget --quiet https://raw.githubusercontent.com/groonga/groonga/main/tools/parse-backtrace.rb
           options=""
@@ -170,8 +166,6 @@ jobs:
             ~/.cache/red-datasets
           key: red-datasets-ubuntu
       - name: Run unit test
-        # TODO: Remove this when we're PostgreSQL 19 ready
-        continue-on-error: ${{ matrix.postgresql-version == '19' && true || false }}
         run: |
           PATH="/usr/lib/postgresql/${{ matrix.postgresql-version }}/bin:$PATH" \
             bundle exec ruby \

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -297,8 +297,9 @@ pgroonga_crash_safer_reindex_one(Datum databaseInfoDatum)
 			}
 			else
 			{
-				indexNames[i] = pnstrdup(VARDATA_ANY(indexName),
-										 VARSIZE_ANY_EXHDR(indexName));
+				indexNames[i] =
+					pnstrdup(VARDATA_ANY(DatumGetPointer(indexName)),
+							 VARSIZE_ANY_EXHDR(DatumGetPointer(indexName)));
 			}
 		}
 

--- a/src/pgroonga-standby-maintainer.c
+++ b/src/pgroonga-standby-maintainer.c
@@ -237,8 +237,9 @@ pgroonga_standby_maintainer_maintain(Datum databaseInfoDatum)
 			}
 			else
 			{
-				indexName = VARDATA_ANY(indexNameDatum);
-				indexNameSize = VARSIZE_ANY_EXHDR(indexNameDatum);
+				indexName = VARDATA_ANY(DatumGetPointer(indexNameDatum));
+				indexNameSize =
+					VARSIZE_ANY_EXHDR(DatumGetPointer(indexNameDatum));
 			}
 			BGWORKER_SET_INDEX_NAME(worker, indexName, indexNameSize);
 		}


### PR DESCRIPTION
`VARDATA_ANY()`/`VARSIZE_ANY_EXHDR` were re-implemented as `static inline` functions:
https://github.com/postgres/postgres/commit/e035863c9a04beeecc254c3bfe48dab58e389e10

So we need to use `const void *` not `Datum` for their arguments. We can use `DatumGetPointer()` for it.

https://github.com/pgroonga/pgroonga/actions/runs/18021762544/job/51280586570#step:8:65

```text
 ../pgroonga/src/pgroonga-crash-safer.c: In function ‘pgroonga_crash_safer_reindex_one’:
../pgroonga/src/pgroonga-crash-safer.c:300:70: warning: passing argument 1 of ‘VARDATA_ANY’ makes pointer from integer without a cast [-Wint-conversion]
  300 |                                 indexNames[i] = pnstrdup(VARDATA_ANY(indexName),
      |                                                                      ^~~~~~~~~
      |                                                                      |
      |                                                                      Datum {aka long unsigned int}
In file included from /usr/include/postgresql/19/server/access/htup_details.h:22,
                 from /usr/include/postgresql/19/server/nodes/tidbitmap.h:25,
                 from /usr/include/postgresql/19/server/access/genam.h:20,
                 from ../pgroonga/src/pgrn-compatible.h:5,
                 from ../pgroonga/src/pgroonga-crash-safer.c:7:
/usr/include/postgresql/19/server/varatt.h:486:25: note: expected ‘const void *’ but argument is of type ‘Datum’ {aka ‘long unsigned int’}
  486 | VARDATA_ANY(const void *PTR)
      |             ~~~~~~~~~~~~^~~
../pgroonga/src/pgroonga-crash-safer.c:301:100: warning: passing argument 1 of ‘VARSIZE_ANY_EXHDR’ makes pointer from integer without a cast [-Wint-conversion]
  301 |                                                                                  VARSIZE_ANY_EXHDR(indexName));
      |                                                                                                    ^~~~~~~~~
      |                                                                                                    |
      |                                                                                                    Datum {aka long unsigned int}
/usr/include/postgresql/19/server/varatt.h:472:31: note: expected ‘const void *’ but argument is of type ‘Datum’ {aka ‘long unsigned int’}
  472 | VARSIZE_ANY_EXHDR(const void *PTR)
      |                   ~~~~~~~~~~~~^~~
```