### PR TITLE
custom-scan: Support multiple columns

### DIFF
--- a/expected/function/score/hot/custom-scan/with-id.out
+++ b/expected/function/score/hot/custom-scan/with-id.out
@@ -9,7 +9,17 @@ INSERT INTO memos VALUES (2, 'groonga', 'Groonga is fast full text search engine
 INSERT INTO memos VALUES (3, 'pgsql', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 UPDATE memos SET tag = 'groonga'
  WHERE id = 3;
-SET groonga.enable_custom_scan = on;
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content, pgroonga_score(memos)
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (PGroongaScan) on memos
+   Filter: (content &@~ 'PGroonga OR Groonga'::text)
+(2 rows)
+
 SELECT id, content, pgroonga_score(memos)
   FROM memos
  WHERE content &@~ 'PGroonga OR Groonga';

--- a/expected/function/score/hot/custom-scan/without-id.out
+++ b/expected/function/score/hot/custom-scan/without-id.out
@@ -9,7 +9,17 @@ INSERT INTO memos VALUES (2, 'groonga', 'Groonga is fast full text search engine
 INSERT INTO memos VALUES (3, 'pgsql', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 UPDATE memos SET tag = 'groonga'
  WHERE id = 3;
-SET groonga.enable_custom_scan = on;
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content, pgroonga_score(tableoid, ctid)
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (PGroongaScan) on memos
+   Filter: (content &@~ 'PGroonga OR Groonga'::text)
+(2 rows)
+
 SELECT id, content, pgroonga_score(tableoid, ctid)
   FROM memos
  WHERE content &@~ 'PGroonga OR Groonga';

--- a/sql/function/score/hot/custom-scan/with-id.sql
+++ b/sql/function/score/hot/custom-scan/with-id.sql
@@ -12,7 +12,12 @@ INSERT INTO memos VALUES (3, 'pgsql', 'PGroonga is a PostgreSQL extension that u
 UPDATE memos SET tag = 'groonga'
  WHERE id = 3;
 
-SET groonga.enable_custom_scan = on;
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content, pgroonga_score(memos)
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
 
 SELECT id, content, pgroonga_score(memos)
   FROM memos

--- a/sql/function/score/hot/custom-scan/without-id.sql
+++ b/sql/function/score/hot/custom-scan/without-id.sql
@@ -12,7 +12,12 @@ INSERT INTO memos VALUES (3, 'pgsql', 'PGroonga is a PostgreSQL extension that u
 UPDATE memos SET tag = 'groonga'
  WHERE id = 3;
 
-SET groonga.enable_custom_scan = on;
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content, pgroonga_score(tableoid, ctid)
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
 
 SELECT id, content, pgroonga_score(tableoid, ctid)
   FROM memos

--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -3,6 +3,7 @@
 #include <postgres.h>
 
 #include <access/genam.h>
+#include <access/heapam.h>
 
 #ifdef _WIN32
 #	define PRId64 "I64d"
@@ -116,4 +117,22 @@ pgrn_index_beginscan(Relation heapRelation,
 #endif
 						   nKeys,
 						   nOrderBys);
+}
+
+static inline bool
+pgrn_heap_fetch(Relation relation,
+				Snapshot snapshot,
+				HeapTuple tuple,
+				Buffer *userbuf,
+				bool keep_buf)
+{
+	return heap_fetch(relation,
+					  snapshot,
+					  tuple,
+					  userbuf
+#if PG_VERSION_NUM >= 150000
+					  ,
+					  keep_buf
+#endif
+	);
 }

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -436,10 +436,12 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 	{
 		GRN_LOG(ctx,
 				GRN_LOG_DEBUG,
-				"%s[dead] <%s>: <%ld>",
+				"%s[dead] <%s>: <(%u,%u),%u>",
 				tag,
 				table->rd_rel->relname.data,
-				packedCtid);
+				ctid.ip_blkid.bi_hi,
+				ctid.ip_blkid.bi_lo,
+				ctid.ip_posid);
 		return NULL;
 	}
 

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -501,7 +501,7 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 					}
 					else
 					{
-						slot->tts_values[ttsIndex] = (Datum) 0;
+						slot->tts_values[ttsIndex] = 0;
 						slot->tts_isnull[ttsIndex] = true;
 					}
 

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -320,16 +320,24 @@ PGrnSearchBuildCustomScanConditions(CustomScanState *customScanState,
 		}
 
 		{
-			int attributeNumber =
-				PGrnGetIndexColumnAttributeNumber(index, column->varattno);
-			Oid opfamily = index->rd_opfamily[attributeNumber - 1];
 			int strategy;
 			Oid leftType;
 			Oid rightType;
 			ScanKeyData scankey;
 
+			int attributeNumber =
+				PGrnGetIndexColumnAttributeNumber(index, column->varattno);
+			if (attributeNumber == 0)
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_UNDEFINED_COLUMN),
+						 errmsg("pgroonga: %s "
+								"attribute number <%d> not found in index",
+								tag,
+								column->varattno)));
+			}
 			get_op_opfamily_properties(opexpr->opno,
-									   opfamily,
+									   index->rd_opfamily[attributeNumber - 1],
 									   false,
 									   &strategy,
 									   &leftType,

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -210,7 +210,7 @@ static bool
 PGrnIndexContainColumn(Relation index, const char *name)
 {
 	TupleDesc tupdesc = RelationGetDescr(index);
-	for (unsigned int i = 0; i < tupdesc->natts; i++)
+	for (AttrNumber i = 0; i < tupdesc->natts; i++)
 	{
 		Form_pg_attribute attr = TupleDescAttr(tupdesc, i);
 		if (strcmp(NameStr(attr->attname), name) == 0)
@@ -250,7 +250,7 @@ static int
 PGrnGetIndexColumnAttributeNumber(Relation index, int tableAttnum)
 {
 	IndexInfo *indexInfo = BuildIndexInfo(index);
-	for (unsigned int i = 0; i < indexInfo->ii_NumIndexAttrs; i++)
+	for (int i = 0; i < indexInfo->ii_NumIndexAttrs; i++)
 	{
 		if (indexInfo->ii_IndexAttrNumbers[i] == tableAttnum)
 		{


### PR DESCRIPTION
This commit is part of the work to implement a custom scan.

It didn't work on a table with multiple columns, so we changed it to work.

The test for `sql/function/score/hot/custom-scan/*` had an incorrect parameter name and was not testing the custom scan.