### PR TITLE
packages: use GH_TOKEN if available

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -156,6 +156,8 @@ jobs:
           key: package-${{ matrix.package-id }}-ccache-${{ hashFiles('src/*.c', 'src/*.h') }}
           restore-keys: package-${{ matrix.package-id }}-ccache-
       - name: Build with Docker
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -x
           cd packages/${PACKAGE}

--- a/helper.rb
+++ b/helper.rb
@@ -35,7 +35,10 @@ module Helper
 
   def detect_latest_groonga_version
     releases_uri = URI("https://api.github.com/repos/groonga/groonga/releases")
-    releases_uri.open do |releases_output|
+    options = {}
+    gh_token = ENV["GH_TOKEN"]
+    options["Authorization"] = "token #{gh_token}" if gh_token
+    releases_uri.open(options) do |releases_output|
       releases = JSON.parse(releases_output.read)
       releases[0]["tag_name"].delete_prefix("v")
     end


### PR DESCRIPTION
GitHub: fix GH-799

It's for avoiding rate limit error in CI.