### PR TITLE
custom-scan: Not add to the plan path when there is no PGroonga index

### DIFF
--- a/expected/custom-scan/no-index.out
+++ b/expected/custom-scan/no-index.out
@@ -1,0 +1,26 @@
+CREATE TABLE ids (
+  id integer
+);
+INSERT INTO ids VALUES (1);
+INSERT INTO ids VALUES (2);
+INSERT INTO ids VALUES (3);
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = 2;
+     QUERY PLAN     
+--------------------
+ Seq Scan on ids
+   Filter: (id = 2)
+(2 rows)
+
+SELECT id
+  FROM ids
+ WHERE id = 2;
+ id 
+----
+  2
+(1 row)
+
+DROP TABLE ids;

--- a/sql/custom-scan/no-index.sql
+++ b/sql/custom-scan/no-index.sql
@@ -1,0 +1,20 @@
+CREATE TABLE ids (
+  id integer
+);
+
+INSERT INTO ids VALUES (1);
+INSERT INTO ids VALUES (2);
+INSERT INTO ids VALUES (3);
+
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id
+  FROM ids
+ WHERE id = 2;
+
+SELECT id
+  FROM ids
+ WHERE id = 2;
+
+DROP TABLE ids;


### PR DESCRIPTION
This commit is part of the work to implement a custom scan.

Even when custom scan is enabled, it is meaningless without an index, so it is not added to the plan path.