### PR TITLE
varchar/query-v2: Fix many-partition test

### DIFF
--- a/expected/full-text-search/varchar/query-v2/partitioning/many-partition.out
+++ b/expected/full-text-search/varchar/query-v2/partitioning/many-partition.out
@@ -22,64 +22,64 @@ CREATE TABLE infection_numbers_influenza_22_04 PARTITION OF infection_numbers_in
 INSERT INTO infection_numbers_influenza_20_04 VALUES ('Japan','Mie','Ise','134','20-04','age: 30, gender:male, overseas travel history: true');
 INSERT INTO infection_numbers_influenza_21_04 VALUES ('Germany','BER','BER','221','21-04','age: 50, gender:male, overseas travel history: false');
 INSERT INTO infection_numbers_influenza_22_04 VALUES ('U.S.A','NY','NY','10221','22-04','age: 10, gender:male, overseas travel history: false');
-CREATE INDEX remarks_index ON infection_numbers_influenza USING pgroonga (remarks);
+CREATE INDEX remarks_index ON infection_numbers_influenza USING pgroonga (remarks pgroonga_varchar_full_text_search_ops_v2);
 \pset format unaligned
 EXPLAIN (COSTS OFF)
 SELECT t1.n_infection, t1.remarks
   FROM infection_numbers_influenza t1
   INNER JOIN infection_numbers_influenza t2
     ON t1.city = t2.prefecture
- WHERE t1.remarks  &@~ 'age'
+ WHERE t1.remarks &@~ 'age'
 \g |sed -r -e "s/ t[1,2](_[0-9]{1,2}){0,1}//g"
 QUERY PLAN
 Hash Join
-  Hash Cond: ((t1.city)::text = (t2.prefecture)::text)
+  Hash Cond: ((t2.prefecture)::text = (t1.city)::text)
   ->  Append
         ->  Seq Scan on infection_numbers_influenza_20_01
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_20_02
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_20_03
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_20_04
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_21_01
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_21_02
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_21_03
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_21_04
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_22_01
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_22_02
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_22_03
-              Filter: (remarks &@~ 'age'::character varying)
         ->  Seq Scan on infection_numbers_influenza_22_04
-              Filter: (remarks &@~ 'age'::character varying)
   ->  Hash
         ->  Append
-              ->  Seq Scan on infection_numbers_influenza_20_01
-              ->  Seq Scan on infection_numbers_influenza_20_02
-              ->  Seq Scan on infection_numbers_influenza_20_03
-              ->  Seq Scan on infection_numbers_influenza_20_04
-              ->  Seq Scan on infection_numbers_influenza_21_01
-              ->  Seq Scan on infection_numbers_influenza_21_02
-              ->  Seq Scan on infection_numbers_influenza_21_03
-              ->  Seq Scan on infection_numbers_influenza_21_04
-              ->  Seq Scan on infection_numbers_influenza_22_01
-              ->  Seq Scan on infection_numbers_influenza_22_02
-              ->  Seq Scan on infection_numbers_influenza_22_03
-              ->  Seq Scan on infection_numbers_influenza_22_04
+              ->  Index Scan using infection_numbers_influenza_20_01_remarks_idx on infection_numbers_influenza_20_01
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_20_02_remarks_idx on infection_numbers_influenza_20_02
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_20_03_remarks_idx on infection_numbers_influenza_20_03
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_20_04_remarks_idx on infection_numbers_influenza_20_04
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_21_01_remarks_idx on infection_numbers_influenza_21_01
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_21_02_remarks_idx on infection_numbers_influenza_21_02
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_21_03_remarks_idx on infection_numbers_influenza_21_03
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_21_04_remarks_idx on infection_numbers_influenza_21_04
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_22_01_remarks_idx on infection_numbers_influenza_22_01
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_22_02_remarks_idx on infection_numbers_influenza_22_02
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_22_03_remarks_idx on infection_numbers_influenza_22_03
+                    Index Cond: (remarks &@~ 'age'::character varying)
+              ->  Index Scan using infection_numbers_influenza_22_04_remarks_idx on infection_numbers_influenza_22_04
+                    Index Cond: (remarks &@~ 'age'::character varying)
 (41 rows)
 \pset format aligned
 SELECT t1.n_infection, t1.remarks
   FROM infection_numbers_influenza t1
   INNER JOIN infection_numbers_influenza t2
     ON t1.city = t2.prefecture
- WHERE t1.remarks  &@~ 'age';
+ WHERE t1.remarks &@~ 'age';
  n_infection |                       remarks                        
 -------------+------------------------------------------------------
  221         | age: 50, gender:male, overseas travel history: false

--- a/sql/full-text-search/varchar/query-v2/partitioning/many-partition.sql
+++ b/sql/full-text-search/varchar/query-v2/partitioning/many-partition.sql
@@ -25,7 +25,7 @@ INSERT INTO infection_numbers_influenza_20_04 VALUES ('Japan','Mie','Ise','134',
 INSERT INTO infection_numbers_influenza_21_04 VALUES ('Germany','BER','BER','221','21-04','age: 50, gender:male, overseas travel history: false');
 INSERT INTO infection_numbers_influenza_22_04 VALUES ('U.S.A','NY','NY','10221','22-04','age: 10, gender:male, overseas travel history: false');
 
-CREATE INDEX remarks_index ON infection_numbers_influenza USING pgroonga (remarks);
+CREATE INDEX remarks_index ON infection_numbers_influenza USING pgroonga (remarks pgroonga_varchar_full_text_search_ops_v2);
 
 \pset format unaligned
 EXPLAIN (COSTS OFF)
@@ -33,7 +33,7 @@ SELECT t1.n_infection, t1.remarks
   FROM infection_numbers_influenza t1
   INNER JOIN infection_numbers_influenza t2
     ON t1.city = t2.prefecture
- WHERE t1.remarks  &@~ 'age'
+ WHERE t1.remarks &@~ 'age'
 \g |sed -r -e "s/ t[1,2](_[0-9]{1,2}){0,1}//g"
 \pset format aligned
 
@@ -41,6 +41,6 @@ SELECT t1.n_infection, t1.remarks
   FROM infection_numbers_influenza t1
   INNER JOIN infection_numbers_influenza t2
     ON t1.city = t2.prefecture
- WHERE t1.remarks  &@~ 'age';
+ WHERE t1.remarks &@~ 'age';
 
 DROP TABLE infection_numbers_influenza;


### PR DESCRIPTION
Specify `pgroonga_varchar_full_text_search_ops_v2` so that `&@~` can be used.