### PR TITLE
ci release: move checkout repository before downloading artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
                          --jq '.[].databaseId' \
                          --json databaseId \
                          --limit 1 \
-                         --repo ${GITHUB_REPOSITORY} \
                          --workflow ${workflow})
               if [ -n "${run_id}" ]; then
                 break
@@ -43,12 +42,10 @@ jobs:
             gh run watch \
               --exit-status \
               --interval 300 \
-              --repo ${GITHUB_REPOSITORY} \
               ${run_id}
             gh run download ${run_id} \
               --dir release-artifacts \
-              --pattern "release-*" \
-              --repo ${GITHUB_REPOSITORY}
+              --pattern "release-*"
           done
         env:
           GH_TOKEN: ${{ github.token }}
@@ -84,7 +81,6 @@ jobs:
           gh release create ${GITHUB_REF_NAME} \
             --discussion-category Releases \
             --notes-file release-note-without-version.md \
-            --repo ${GITHUB_REPOSITORY} \
             --title "${title}" \
             release-artifacts/*/*
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/checkout@v5
+        with:
+          repository: "pgroonga/pgroonga.github.io"
+          path: "pgroonga.github.io"
       - name: Download artifacts
         if: |
           github.ref_type == 'tag'
@@ -45,13 +52,6 @@ jobs:
           done
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - uses: actions/checkout@v5
-        with:
-          repository: "pgroonga/pgroonga.github.io"
-          path: "pgroonga.github.io"
       - name: Extract release note
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fix: GH-818,

"actions/checkout" removing the contents of '/home/runner/work/pgroonga/pgroonga'. 
So, if we execute "actions/checkout" after downloading artifacts, "actions/checkout" remove "release-artifacts" directory.