### PR TITLE
custom-scan: No custom scan for unsupported operators

### DIFF
--- a/expected/custom-scan/unsupported-operator.out
+++ b/expected/custom-scan/unsupported-operator.out
@@ -1,0 +1,27 @@
+CREATE TABLE tags (
+    tag varchar(200)
+);
+INSERT INTO tags VALUES ('Fuji');
+INSERT INTO tags VALUES ('Hawk');
+INSERT INTO tags VALUES ('Eggplant');
+CREATE INDEX tag_index ON tags USING pgroonga (tag);
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT tag
+  FROM tags
+ WHERE tag &@~ 'fuji';
+                  QUERY PLAN                   
+-----------------------------------------------
+ Seq Scan on tags
+   Filter: (tag &@~ 'fuji'::character varying)
+(2 rows)
+
+SELECT tag
+  FROM tags
+ WHERE tag &@~ 'fuji';
+ tag  
+------
+ Fuji
+(1 row)
+
+DROP TABLE tags;

--- a/sql/custom-scan/unsupported-operator.sql
+++ b/sql/custom-scan/unsupported-operator.sql
@@ -1,0 +1,22 @@
+CREATE TABLE tags (
+    tag varchar(200)
+);
+
+INSERT INTO tags VALUES ('Fuji');
+INSERT INTO tags VALUES ('Hawk');
+INSERT INTO tags VALUES ('Eggplant');
+
+CREATE INDEX tag_index ON tags USING pgroonga (tag);
+
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT tag
+  FROM tags
+ WHERE tag &@~ 'fuji';
+
+SELECT tag
+  FROM tags
+ WHERE tag &@~ 'fuji';
+
+DROP TABLE tags;


### PR DESCRIPTION
This commit is part of the work to implement a custom scan.

For unsupported operators, a standard scan will be executed.