### PR TITLE
custom-scan: Prepare to support parallel scan

### DIFF
--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -61,6 +61,18 @@ static void PGrnReScanCustomScan(CustomScanState *node);
 static void
 PGrnExplainCustomScan(CustomScanState *node, List *ancestors, ExplainState *es);
 
+static Size PGrnEstimateDSMCustomScan(CustomScanState *customScanState,
+									  ParallelContext *pcxt);
+static void PGrnInitializeDSMCustomScan(CustomScanState *customScanState,
+										ParallelContext *pcxt,
+										void *coordinate);
+static void PGrnReInitializeDSMCustomScan(CustomScanState *customScanState,
+										  ParallelContext *pcxt,
+										  void *coordinate);
+static void PGrnInitializeWorkerCustomScan(CustomScanState *customScanState,
+										   shm_toc *toc,
+										   void *coordinate);
+
 const struct CustomPathMethods PGrnPathMethods = {
 	.CustomName = "PGroongaScan",
 	.PlanCustomPath = PGrnPlanCustomPath,
@@ -81,6 +93,11 @@ const struct CustomExecMethods PGrnExecuteMethods = {
 	.ReScanCustomScan = PGrnReScanCustomScan,
 
 	.ExplainCustomScan = PGrnExplainCustomScan,
+
+	.EstimateDSMCustomScan = PGrnEstimateDSMCustomScan,
+	.InitializeDSMCustomScan = PGrnInitializeDSMCustomScan,
+	.ReInitializeDSMCustomScan = PGrnReInitializeDSMCustomScan,
+	.InitializeWorkerCustomScan = PGrnInitializeWorkerCustomScan,
 };
 
 bool
@@ -427,6 +444,12 @@ PGrnSetRelPathlistHook(PlannerInfo *root,
 	cpath->path.pathtype = T_CustomScan;
 	cpath->path.parent = rel;
 	cpath->path.pathtarget = rel->reltarget;
+
+	// todo
+	// Set appropriately according to the function to be executed.
+	// cpath->path.parallel_aware = true;
+	// cpath->path.parallel_safe = true;
+
 	cpath->custom_private = privateData;
 
 #if (PG_VERSION_NUM >= 150000)
@@ -813,6 +836,34 @@ PGrnEndCustomScan(CustomScanState *customScanState)
 
 static void
 PGrnReScanCustomScan(CustomScanState *node)
+{
+}
+
+static Size
+PGrnEstimateDSMCustomScan(CustomScanState *customScanState,
+						  ParallelContext *pcxt)
+{
+	return 0;
+}
+
+static void
+PGrnInitializeDSMCustomScan(CustomScanState *customScanState,
+							ParallelContext *pcxt,
+							void *coordinate)
+{
+}
+
+static void
+PGrnReInitializeDSMCustomScan(CustomScanState *customScanState,
+							  ParallelContext *pcxt,
+							  void *coordinate)
+{
+}
+
+static void
+PGrnInitializeWorkerCustomScan(CustomScanState *customScanState,
+							   shm_toc *toc,
+							   void *coordinate)
 {
 }
 


### PR DESCRIPTION
Added the necessary functions. First, add them as empty:

* PGrnEstimateDSMCustomScan
* PGrnInitializeDSMCustomScan
* PGrnReInitializeDSMCustomScan
* PGrnInitializeWorkerCustomScan