### PR TITLE
custom-scan: Disable registered functions

### DIFF
--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -337,9 +337,6 @@ PGrnSetRelPathlistHook(PlannerInfo *root,
 	CustomPath *cpath;
 	List *privateData = NIL;
 
-	if (!PGrnCustomScanInitialized)
-		return;
-
 	if (PreviousSetRelPathlistHook)
 	{
 		PreviousSetRelPathlistHook(root, rel, rti, rte);


### PR DESCRIPTION
Since there is no UnregisterCustomScanMethods() that is paired with RegisterCustomScanMethods(), we added a `PGrnCustomScanInitialized` flag, and when the flag is disabled, each function does nothing.