### PR TITLE
custom-scan: Support indexes on varchar columns

### DIFF
--- a/expected/term-search/varchar/equal/custom-scan.out
+++ b/expected/term-search/varchar/equal/custom-scan.out
@@ -1,0 +1,35 @@
+CREATE TABLE tags (
+  id int,
+  name varchar
+);
+INSERT INTO tags VALUES (1, 'PostgreSQL');
+INSERT INTO tags VALUES (2, 'Groonga');
+INSERT INTO tags VALUES (3, 'groonga');
+INSERT INTO tags VALUES (4, 'PGroonga');
+CREATE INDEX pgrn_index ON tags
+  USING pgroonga (name pgroonga_varchar_term_search_ops_v2);
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT name
+  FROM tags
+ WHERE name &= 'groonga'
+ ORDER BY id;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Custom Scan (PGroongaScan) on tags
+         Filter: (name &= 'groonga'::character varying)
+(4 rows)
+
+SELECT name
+  FROM tags
+ WHERE name &= 'groonga'
+ ORDER BY id;
+  name   
+---------
+ Groonga
+ groonga
+(2 rows)
+
+DROP TABLE tags;

--- a/sql/term-search/varchar/equal/custom-scan.sql
+++ b/sql/term-search/varchar/equal/custom-scan.sql
@@ -1,0 +1,27 @@
+CREATE TABLE tags (
+  id int,
+  name varchar
+);
+
+INSERT INTO tags VALUES (1, 'PostgreSQL');
+INSERT INTO tags VALUES (2, 'Groonga');
+INSERT INTO tags VALUES (3, 'groonga');
+INSERT INTO tags VALUES (4, 'PGroonga');
+
+CREATE INDEX pgrn_index ON tags
+  USING pgroonga (name pgroonga_varchar_term_search_ops_v2);
+
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT name
+  FROM tags
+ WHERE name &= 'groonga'
+ ORDER BY id;
+
+SELECT name
+  FROM tags
+ WHERE name &= 'groonga'
+ ORDER BY id;
+
+DROP TABLE tags;

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -501,8 +501,12 @@ PGrnIndexContainColumn(Relation index, const char *name)
 static bool
 PGrnIsIndexValueUsed(Relation index, const char *columnName, Oid typeID)
 {
-	if (typeID == JSONBOID)
+	switch (typeID)
+	{
+	case JSONBOID:
+	case VARCHAROID:
 		return false;
+	}
 	return PGrnIndexContainColumn(index, columnName);
 }
 


### PR DESCRIPTION
Since the data in the varchar index is normalized, so the data from the table is returned.