### PR TITLE
custom-scan: Skip dead records

### DIFF
--- a/expected/custom-scan/dead.out
+++ b/expected/custom-scan/dead.out
@@ -1,0 +1,32 @@
+CREATE TABLE memos (
+  id integer PRIMARY KEY,
+  content text
+);
+CREATE INDEX grnindex ON memos USING pgroonga (id, content);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+UPDATE memos
+   SET content = 'PGroonga is a PostgreSQL extension that uses Groonga!!!'
+ WHERE id = 3;
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (PGroongaScan) on memos
+   Filter: (content &@~ 'PGroonga OR Groonga'::text)
+(2 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+ id |                         content                         
+----+---------------------------------------------------------
+  3 | PGroonga is a PostgreSQL extension that uses Groonga!!!
+  2 | Groonga is fast full text search engine.
+(2 rows)
+
+DROP TABLE memos;

--- a/sql/custom-scan/dead.sql
+++ b/sql/custom-scan/dead.sql
@@ -1,0 +1,26 @@
+CREATE TABLE memos (
+  id integer PRIMARY KEY,
+  content text
+);
+
+CREATE INDEX grnindex ON memos USING pgroonga (id, content);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+UPDATE memos
+   SET content = 'PGroonga is a PostgreSQL extension that uses Groonga!!!'
+ WHERE id = 3;
+
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga';
+
+DROP TABLE memos;

--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -686,16 +686,19 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 	if (!state->tableCursor)
 		return NULL;
 
-	id = grn_table_cursor_next(ctx, state->tableCursor);
-	if (id == GRN_ID_NIL)
-		return NULL;
-
-	GRN_BULK_REWIND(&(state->columnValue));
-	grn_obj_get_value(ctx, state->ctidAccessor, id, &(state->columnValue));
-	packedCtid = GRN_UINT64_VALUE(&(state->columnValue));
-	ctid = PGrnCtidUnpack(packedCtid);
-	if (!PGrnCtidIsAlive(table, &ctid))
+	while (true)
 	{
+		id = grn_table_cursor_next(ctx, state->tableCursor);
+		if (id == GRN_ID_NIL)
+			return NULL;
+
+		GRN_BULK_REWIND(&(state->columnValue));
+		grn_obj_get_value(ctx, state->ctidAccessor, id, &(state->columnValue));
+		packedCtid = GRN_UINT64_VALUE(&(state->columnValue));
+		ctid = PGrnCtidUnpack(packedCtid);
+		if (PGrnCtidIsAlive(table, &ctid))
+			break;
+
 		GRN_LOG(ctx,
 				GRN_LOG_DEBUG,
 				"%s[dead] <%s>: <(%u,%u),%u>",
@@ -704,7 +707,6 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 				ctid.ip_blkid.bi_hi,
 				ctid.ip_blkid.bi_lo,
 				ctid.ip_posid);
-		return NULL;
 	}
 
 	{


### PR DESCRIPTION
If a record is dead during processing, skip it and retrieve the next record.
Returning `NULL` in ExecCustomScan means "no more records", so instead of returning `NULL`, we move on to the next record.