### PR TITLE
custom-scan: Refactoring

### DIFF
--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -768,9 +768,9 @@ PGrnBeginCustomScan(CustomScanState *customScanState,
 }
 
 static TupleTableSlot *
-PGrnResultTupleSlot(CustomScanState *customScanState,
-					grn_id id,
-					ItemPointerData ctid)
+PGrnMakeTupleTableSlot(CustomScanState *customScanState,
+					   grn_id id,
+					   ItemPointerData ctid)
 {
 	PGrnScanState *state = (PGrnScanState *) customScanState;
 	Relation table = customScanState->ss.ss_currentRelation;
@@ -898,7 +898,7 @@ PGrnExecCustomScan(CustomScanState *customScanState)
 					ctid.ip_posid);
 			continue;
 		}
-		return PGrnResultTupleSlot(customScanState, id, ctid);
+		return PGrnMakeTupleTableSlot(customScanState, id, ctid);
 	}
 	return NULL;
 }


### PR DESCRIPTION
* Unify the argument name of CustomScanState to customScanState.
* Create a function that sets ResultTupleSlot in ExecCustomScan.
  * There are no changes to the logic.
  * This is preparation for changing ExecCustomScan later.
* Add initialization of state->ctidAccessor.
  * This is more of an addition to fix an omission rather than refactoring.