### PR TITLE
custom-scan: Support multiple conditions

### DIFF
--- a/expected/custom-scan/multiple-condition/index-only-and.out
+++ b/expected/custom-scan/multiple-condition/index-only-and.out
@@ -1,0 +1,31 @@
+CREATE TABLE memos (
+  id integer PRIMARY KEY,
+  tag varchar(256),
+  content text
+);
+CREATE INDEX content_index ON memos USING pgroonga (id, content);
+INSERT INTO memos VALUES (1, 'pgsql', 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'groonga', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'pgroonga', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+INSERT INTO memos VALUES (4, 'groonga', 'I like Groonga.');
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Custom Scan (PGroongaScan) on memos
+   Filter: ((id >= 3) AND (content &@~ 'PGroonga OR Groonga'::text))
+(2 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+ id |                        content                        
+----+-------------------------------------------------------
+  3 | PGroonga is a PostgreSQL extension that uses Groonga.
+  4 | I like Groonga.
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/custom-scan/multiple-condition/mix-and.out
+++ b/expected/custom-scan/multiple-condition/mix-and.out
@@ -1,0 +1,31 @@
+CREATE TABLE memos (
+  id integer PRIMARY KEY,
+  tag varchar(256),
+  content text
+);
+CREATE INDEX content_index ON memos USING pgroonga (content);
+INSERT INTO memos VALUES (1, 'pgsql', 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'groonga', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'pgroonga', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+INSERT INTO memos VALUES (4, 'groonga', 'I like Groonga.');
+SET pgroonga.enable_custom_scan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Custom Scan (PGroongaScan) on memos
+   Filter: ((id >= 3) AND (content &@~ 'PGroonga OR Groonga'::text))
+(2 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+ id |                        content                        
+----+-------------------------------------------------------
+  3 | PGroonga is a PostgreSQL extension that uses Groonga.
+  4 | I like Groonga.
+(2 rows)
+
+DROP TABLE memos;

--- a/sql/custom-scan/multiple-condition/index-only-and.sql
+++ b/sql/custom-scan/multiple-condition/index-only-and.sql
@@ -1,0 +1,25 @@
+CREATE TABLE memos (
+  id integer PRIMARY KEY,
+  tag varchar(256),
+  content text
+);
+
+CREATE INDEX content_index ON memos USING pgroonga (id, content);
+
+INSERT INTO memos VALUES (1, 'pgsql', 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'groonga', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'pgroonga', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+INSERT INTO memos VALUES (4, 'groonga', 'I like Groonga.');
+
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+
+DROP TABLE memos;

--- a/sql/custom-scan/multiple-condition/mix-and.sql
+++ b/sql/custom-scan/multiple-condition/mix-and.sql
@@ -1,0 +1,25 @@
+CREATE TABLE memos (
+  id integer PRIMARY KEY,
+  tag varchar(256),
+  content text
+);
+
+CREATE INDEX content_index ON memos USING pgroonga (content);
+
+INSERT INTO memos VALUES (1, 'pgsql', 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'groonga', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'pgroonga', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+INSERT INTO memos VALUES (4, 'groonga', 'I like Groonga.');
+
+SET pgroonga.enable_custom_scan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@~ 'PGroonga OR Groonga' AND id >= 3;
+
+DROP TABLE memos;


### PR DESCRIPTION
Columns that are not included in the index are stored separately and evaluated in ExecQual() for filtering.

* sql/custom-scan/multiple-condition/mix-and.sql
  * It is when there are columns that are not included in the index.
  * This commit adds support for this case.
* sql/custom-scan/multiple-condition/index-only-and.sql
  * Conditions with multiple columns included in the index were already supported.
  * It worked as expected even without this commit.