### PR TITLE
test term-search/text/equal-v2: fix row level security tests

### DIFF
--- a/expected/term-search/text/equal-v2/row-level-security/bitmapscan.out
+++ b/expected/term-search/text/equal-v2/row-level-security/bitmapscan.out
@@ -5,7 +5,7 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (1, 'nonexistent', 'groonga');
 INSERT INTO tags VALUES (2, 'alice', 'Groonga');
 INSERT INTO tags VALUES (3, 'alice', 'groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');

--- a/expected/term-search/text/equal-v2/row-level-security/indexscan.out
+++ b/expected/term-search/text/equal-v2/row-level-security/indexscan.out
@@ -5,7 +5,7 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (1, 'nonexistent', 'groonga');
 INSERT INTO tags VALUES (2, 'alice', 'Groonga');
 INSERT INTO tags VALUES (3, 'alice', 'groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');

--- a/expected/term-search/text/equal-v2/row-level-security/seqscan.out
+++ b/expected/term-search/text/equal-v2/row-level-security/seqscan.out
@@ -5,7 +5,7 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (1, 'nonexistent', 'groonga');
 INSERT INTO tags VALUES (2, 'alice', 'Groonga');
 INSERT INTO tags VALUES (3, 'alice', 'groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');

--- a/sql/term-search/text/equal-v2/row-level-security/bitmapscan.sql
+++ b/sql/term-search/text/equal-v2/row-level-security/bitmapscan.sql
@@ -7,7 +7,7 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (1, 'nonexistent', 'groonga');
 INSERT INTO tags VALUES (2, 'alice', 'Groonga');
 INSERT INTO tags VALUES (3, 'alice', 'groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');

--- a/sql/term-search/text/equal-v2/row-level-security/indexscan.sql
+++ b/sql/term-search/text/equal-v2/row-level-security/indexscan.sql
@@ -7,7 +7,7 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (1, 'nonexistent', 'groonga');
 INSERT INTO tags VALUES (2, 'alice', 'Groonga');
 INSERT INTO tags VALUES (3, 'alice', 'groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');

--- a/sql/term-search/text/equal-v2/row-level-security/seqscan.sql
+++ b/sql/term-search/text/equal-v2/row-level-security/seqscan.sql
@@ -7,7 +7,7 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (1, 'nonexistent', 'groonga');
 INSERT INTO tags VALUES (2, 'alice', 'Groonga');
 INSERT INTO tags VALUES (3, 'alice', 'groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');


### PR DESCRIPTION
GitHub: GH-849

The first test row had user_name 'nonexistent' but content 'PostgreSQL', which made the RLS condition ineffective since the test queries search for
'groonga'.

Changed the content to 'groonga' to properly test that the row is filtered out by RLS policy.

Note: Custom scans do not currently support RLS.
Similar test fixes in other test suites will be
addressed separately.