### PR TITLE
test term-search/text/not-prefix-in: fix row level security tests

### DIFF
--- a/expected/term-search/text/not-prefix-in/row-level-security/bitmapscan.out
+++ b/expected/term-search/text/not-prefix-in/row-level-security/bitmapscan.out
@@ -6,7 +6,7 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'nonexistent', 'rroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'Rroonga');
 INSERT INTO tags VALUES (3, 'alice', 'Groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
 INSERT INTO tags VALUES (5, 'alice', 'pglogical');

--- a/expected/term-search/text/not-prefix-in/row-level-security/indexscan.out
+++ b/expected/term-search/text/not-prefix-in/row-level-security/indexscan.out
@@ -6,7 +6,7 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'nonexistent', 'rroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'Rroonga');
 INSERT INTO tags VALUES (3, 'alice', 'Groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
 INSERT INTO tags VALUES (5, 'alice', 'pglogical');

--- a/expected/term-search/text/not-prefix-in/row-level-security/seqscan.out
+++ b/expected/term-search/text/not-prefix-in/row-level-security/seqscan.out
@@ -6,7 +6,7 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'nonexistent', 'rroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'Rroonga');
 INSERT INTO tags VALUES (3, 'alice', 'Groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
 INSERT INTO tags VALUES (5, 'alice', 'pglogical');

--- a/sql/term-search/text/not-prefix-in/row-level-security/bitmapscan.sql
+++ b/sql/term-search/text/not-prefix-in/row-level-security/bitmapscan.sql
@@ -8,7 +8,7 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'nonexistent', 'rroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'Rroonga');
 INSERT INTO tags VALUES (3, 'alice', 'Groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
 INSERT INTO tags VALUES (5, 'alice', 'pglogical');

--- a/sql/term-search/text/not-prefix-in/row-level-security/indexscan.sql
+++ b/sql/term-search/text/not-prefix-in/row-level-security/indexscan.sql
@@ -8,7 +8,7 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'nonexistent', 'rroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'Rroonga');
 INSERT INTO tags VALUES (3, 'alice', 'Groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
 INSERT INTO tags VALUES (5, 'alice', 'pglogical');

--- a/sql/term-search/text/not-prefix-in/row-level-security/seqscan.sql
+++ b/sql/term-search/text/not-prefix-in/row-level-security/seqscan.sql
@@ -8,7 +8,7 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'nonexistent', 'rroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'Rroonga');
 INSERT INTO tags VALUES (3, 'alice', 'Groonga');
 INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
 INSERT INTO tags VALUES (5, 'alice', 'pglogical');


### PR DESCRIPTION
GitHub: GH-849

The first test row had user_name 'nonexistent' but content 'PostgreSQL', which made the RLS condition ineffective since the test queries uses
the `name !&^| ARRAY['gro', 'pos']` condition.

Added the content to 'Rroonga' to properly test
that the row is filtered out by RLS policy.

Note: Custom scans do not currently support RLS.
Similar test fixes in other test suites will be
addressed separately.