### PR TITLE
test term-search/text/prefix: fix row level security tests

### DIFF
--- a/expected/term-search/text/prefix/row-level-security/bitmapscan.out
+++ b/expected/term-search/text/prefix/row-level-security/bitmapscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/text/prefix/row-level-security/indexscan.out
+++ b/expected/term-search/text/prefix/row-level-security/indexscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/text/prefix/row-level-security/seqscan.out
+++ b/expected/term-search/text/prefix/row-level-security/seqscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regrsess');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 SET enable_seqscan = on;

--- a/sql/term-search/text/prefix/row-level-security/bitmapscan.sql
+++ b/sql/term-search/text/prefix/row-level-security/bitmapscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/text/prefix/row-level-security/indexscan.sql
+++ b/sql/term-search/text/prefix/row-level-security/indexscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/text/prefix/row-level-security/seqscan.sql
+++ b/sql/term-search/text/prefix/row-level-security/seqscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regrsess');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);


### PR DESCRIPTION
GitHub: GH-849

The first test row had user_name 'nonexistent' but content 'PostgreSQL', which made the RLS condition ineffective since the test queries uses
the `name &^ 'pG'` condition.

Added the content to 'pg_regress' to properly test that the row is filtered out by RLS policy.

Note: Custom scans do not currently support RLS.
Similar test fixes in other test suites will be
addressed separately.