### PR TITLE
test term-search/text/prefix-fts-condition: fix row level security tests

### DIFF
--- a/expected/term-search/text/prefix-fts-condition/row-level-security/bitmapscan.out
+++ b/expected/term-search/text/prefix-fts-condition/row-level-security/bitmapscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/text/prefix-fts-condition/row-level-security/indexscan.out
+++ b/expected/term-search/text/prefix-fts-condition/row-level-security/indexscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/text/prefix-fts-condition/row-level-security/seqscan.out
+++ b/expected/term-search/text/prefix-fts-condition/row-level-security/seqscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/sql/term-search/text/prefix-fts-condition/row-level-security/bitmapscan.sql
+++ b/sql/term-search/text/prefix-fts-condition/row-level-security/bitmapscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/text/prefix-fts-condition/row-level-security/indexscan.sql
+++ b/sql/term-search/text/prefix-fts-condition/row-level-security/indexscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/text/prefix-fts-condition/row-level-security/seqscan.sql
+++ b/sql/term-search/text/prefix-fts-condition/row-level-security/seqscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'PGroonga');
-INSERT INTO tags VALUES (4, 'alice', 'pglogical');
+INSERT INTO tags VALUES (1, 'nonexistent', 'pg_regress');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (5, 'alice', 'pglogical');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);


### PR DESCRIPTION
GitHub: GH-849

The first test row used user_name 'nonexistent  with content 'PostgreSQL'.
Given the query `name &^ ('-p_G', NULL, 'pgrn_index')::pgroonga_full_text_search_condition` the RLS check wasn’t exercised.

Adding the additional record with 'pg_regress', the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.