### PR TITLE
test term-search/text/equal-fts-condition-v2: fix row level security tests

### DIFF
--- a/expected/term-search/text/equal-fts-condition-v2/row-level-security/bitmapscan.out
+++ b/expected/term-search/text/equal-fts-condition-v2/row-level-security/bitmapscan.out
@@ -6,9 +6,10 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/text/equal-fts-condition-v2/row-level-security/indexscan.out
+++ b/expected/term-search/text/equal-fts-condition-v2/row-level-security/indexscan.out
@@ -6,9 +6,10 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/text/equal-fts-condition-v2/row-level-security/seqscan.out
+++ b/expected/term-search/text/equal-fts-condition-v2/row-level-security/seqscan.out
@@ -6,9 +6,10 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/sql/term-search/text/equal-fts-condition-v2/row-level-security/bitmapscan.sql
+++ b/sql/term-search/text/equal-fts-condition-v2/row-level-security/bitmapscan.sql
@@ -8,9 +8,10 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/text/equal-fts-condition-v2/row-level-security/indexscan.sql
+++ b/sql/term-search/text/equal-fts-condition-v2/row-level-security/indexscan.sql
@@ -8,9 +8,10 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/text/equal-fts-condition-v2/row-level-security/seqscan.sql
+++ b/sql/term-search/text/equal-fts-condition-v2/row-level-security/seqscan.sql
@@ -8,9 +8,10 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
 INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (2, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);


### PR DESCRIPTION
GitHub: GH-849

The first test row used user_name 'nonexistent'  with content 'PostgreSQL'. Given the query `name &= ('groonga', NULL, 'pgrn_index')::pgroonga_full_text_search_condition`, the RLS check was used but doesn't effect the last result. It's because 'PostgreSQL' doesn't match with 'groonga'.

If we add the additional record with 'GROONGA' that matches with 'groonga', we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.