### PR TITLE
test term-search/varchar-array/contain-v2: fix row level security tests

### DIFF
--- a/expected/term-search/varchar-array/contain-v2/row-level-security/bitmapscan.out
+++ b/expected/term-search/varchar-array/contain-v2/row-level-security/bitmapscan.out
@@ -6,8 +6,9 @@ CREATE TABLE memos (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES (1, 'nonexistent', ARRAY['PostgreSQL']);
-INSERT INTO memos VALUES (2, 'alice', ARRAY['Groonga']);
-INSERT INTO memos VALUES (3, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (2, 'nonexistent', ARRAY['PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (3, 'alice', ARRAY['Groonga']);
+INSERT INTO memos VALUES (4, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);
 CREATE INDEX pgrn_index ON memos

--- a/expected/term-search/varchar-array/contain-v2/row-level-security/indexscan.out
+++ b/expected/term-search/varchar-array/contain-v2/row-level-security/indexscan.out
@@ -6,8 +6,9 @@ CREATE TABLE memos (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES (1, 'nonexistent', ARRAY['PostgreSQL']);
-INSERT INTO memos VALUES (2, 'alice', ARRAY['Groonga']);
-INSERT INTO memos VALUES (3, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (2, 'nonexistent', ARRAY['PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (3, 'alice', ARRAY['Groonga']);
+INSERT INTO memos VALUES (4, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);
 CREATE INDEX pgrn_index ON memos

--- a/expected/term-search/varchar-array/contain-v2/row-level-security/seqscan.out
+++ b/expected/term-search/varchar-array/contain-v2/row-level-security/seqscan.out
@@ -6,8 +6,9 @@ CREATE TABLE memos (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES (1, 'nonexistent', ARRAY['PostgreSQL']);
-INSERT INTO memos VALUES (2, 'alice', ARRAY['Groonga']);
-INSERT INTO memos VALUES (3, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (2, 'nonexistent', ARRAY['PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (3, 'alice', ARRAY['Groonga']);
+INSERT INTO memos VALUES (4, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);
 CREATE INDEX pgrn_index ON memos

--- a/sql/term-search/varchar-array/contain-v2/row-level-security/bitmapscan.sql
+++ b/sql/term-search/varchar-array/contain-v2/row-level-security/bitmapscan.sql
@@ -8,8 +8,9 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE memos TO alice;
 
 INSERT INTO memos VALUES (1, 'nonexistent', ARRAY['PostgreSQL']);
-INSERT INTO memos VALUES (2, 'alice', ARRAY['Groonga']);
-INSERT INTO memos VALUES (3, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (2, 'nonexistent', ARRAY['PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (3, 'alice', ARRAY['Groonga']);
+INSERT INTO memos VALUES (4, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
 
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);

--- a/sql/term-search/varchar-array/contain-v2/row-level-security/indexscan.sql
+++ b/sql/term-search/varchar-array/contain-v2/row-level-security/indexscan.sql
@@ -8,8 +8,9 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE memos TO alice;
 
 INSERT INTO memos VALUES (1, 'nonexistent', ARRAY['PostgreSQL']);
-INSERT INTO memos VALUES (2, 'alice', ARRAY['Groonga']);
-INSERT INTO memos VALUES (3, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (2, 'nonexistent', ARRAY['PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (3, 'alice', ARRAY['Groonga']);
+INSERT INTO memos VALUES (4, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
 
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);

--- a/sql/term-search/varchar-array/contain-v2/row-level-security/seqscan.sql
+++ b/sql/term-search/varchar-array/contain-v2/row-level-security/seqscan.sql
@@ -8,8 +8,9 @@ CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE memos TO alice;
 
 INSERT INTO memos VALUES (1, 'nonexistent', ARRAY['PostgreSQL']);
-INSERT INTO memos VALUES (2, 'alice', ARRAY['Groonga']);
-INSERT INTO memos VALUES (3, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (2, 'nonexistent', ARRAY['PostgreSQL', 'Groonga']);
+INSERT INTO memos VALUES (3, 'alice', ARRAY['Groonga']);
+INSERT INTO memos VALUES (4, 'alice', ARRAY['PGroonga', 'PostgreSQL', 'Groonga']);
 
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with content `ARRAY['PostgreSQL']`. Given the query `tags &> 'Groonga'`, the RLS check was used but doesn't effect the last result. It's because `ARRAY['PostgreSQL']` doesn't contain 'Groonga'.

If we add the additional record with `ARRAY['PostgreSQL', 'Groonga']` that contains `'Groonga'`, we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.