### PR TITLE
test term-search/varchar-array/equal-query-fts-condition-v2: fix row level security tests

### DIFF
--- a/expected/term-search/varchar-array/equal-query-fts-condition-v2/row-level-security/seqscan.out
+++ b/expected/term-search/varchar-array/equal-query-fts-condition-v2/row-level-security/seqscan.out
@@ -9,7 +9,7 @@ INSERT INTO tags VALUES (1, 'alice', ARRAY['PostgreSQL', 'ポスグレ']);
 INSERT INTO tags VALUES (2, 'alice', ARRAY['Groonga', 'グルンガ']);
 INSERT INTO tags VALUES (3, 'alice', ARRAY['PGroonga', 'ピージールンガ']);
 INSERT INTO tags VALUES (4, 'nonexistent', ARRAY['Mroonga', 'ムルンガ']);
-INSERT INTO tags VALUES (4, 'nonexistent', ARRAY['groonga', 'グルンガ']);
+INSERT INTO tags VALUES (5, 'nonexistent', ARRAY['Groonga', 'ぐるんが']);
 CREATE INDEX pgroonga_index ON tags
   USING pgroonga (names pgroonga_varchar_array_term_search_ops_v2)
   WITH (normalizer = 'NormalizerNFKC150("unify_kana", true)');

--- a/sql/term-search/varchar-array/equal-query-fts-condition-v2/row-level-security/seqscan.sql
+++ b/sql/term-search/varchar-array/equal-query-fts-condition-v2/row-level-security/seqscan.sql
@@ -11,7 +11,7 @@ INSERT INTO tags VALUES (1, 'alice', ARRAY['PostgreSQL', 'ポスグレ']);
 INSERT INTO tags VALUES (2, 'alice', ARRAY['Groonga', 'グルンガ']);
 INSERT INTO tags VALUES (3, 'alice', ARRAY['PGroonga', 'ピージールンガ']);
 INSERT INTO tags VALUES (4, 'nonexistent', ARRAY['Mroonga', 'ムルンガ']);
-INSERT INTO tags VALUES (4, 'nonexistent', ARRAY['groonga', 'グルンガ']);
+INSERT INTO tags VALUES (5, 'nonexistent', ARRAY['Groonga', 'ぐるんが']);
 
 CREATE INDEX pgroonga_index ON tags
   USING pgroonga (names pgroonga_varchar_array_term_search_ops_v2)


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with content `ARRAY['Mroonga', 'ムルンガ']`. Given the query `names &=~ ('ぽすぐれ OR ぐるんが', NULL, 'pgroonga_index')::pgroonga_full_text_search_condition`, the RLS check was used but doesn't effect the last result. It's because `ARRAY['Mroonga', 'ムルンガ']` doesn't contain 'ぽすぐれ` nor `ぐるんが' (Kana insensitive).

If we add the additional record with `ARRAY['groonga', 'ぐるんが']` that contains `'ぐるんが'`, we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.