### PR TITLE
test term-search/varchar/equal/row-level-security: fix row level security tests

### DIFF
--- a/expected/term-search/varchar/equal/row-level-security/bitmapscan.out
+++ b/expected/term-search/varchar/equal/row-level-security/bitmapscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (1, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/varchar/equal/row-level-security/indexscan.out
+++ b/expected/term-search/varchar/equal/row-level-security/indexscan.out
@@ -5,10 +5,11 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (1, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
 CREATE INDEX pgrn_index ON tags

--- a/expected/term-search/varchar/equal/row-level-security/seqscan.out
+++ b/expected/term-search/varchar/equal/row-level-security/seqscan.out
@@ -5,12 +5,15 @@ CREATE TABLE tags (
 );
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (1, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
+CREATE INDEX pgrn_index ON tags
+ USING pgroonga (name pgroonga_varchar_term_search_ops_v2);
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
@@ -19,24 +22,25 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT name
   FROM tags
- WHERE name &= 'groonga'
+ WHERE name &= pgroonga_condition('groonga', index_name => 'pgrn_index')
  ORDER BY id
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 QUERY PLAN
 Sort
   Sort Key: id
   ->  Seq Scan on tags
-        Filter: ((user_name = CURRENT_USER) AND (name &= 'groonga'::character varying))
+        Filter: ((user_name = CURRENT_USER) AND (name &= '(groonga,,,,pgrn_index,,)'::pgroonga_condition))
 (4 rows)
 \pset format aligned
 SELECT name
   FROM tags
- WHERE name &= 'groonga'
+ WHERE name &= pgroonga_condition('groonga', index_name => 'pgrn_index')
  ORDER BY id;
   name   
 ---------
+ Groonga
  groonga
-(1 row)
+(2 rows)
 
 RESET SESSION AUTHORIZATION;
 DROP TABLE tags;

--- a/sql/term-search/varchar/equal/row-level-security/bitmapscan.sql
+++ b/sql/term-search/varchar/equal/row-level-security/bitmapscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (1, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/varchar/equal/row-level-security/indexscan.sql
+++ b/sql/term-search/varchar/equal/row-level-security/indexscan.sql
@@ -7,10 +7,11 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (1, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);

--- a/sql/term-search/varchar/equal/row-level-security/seqscan.sql
+++ b/sql/term-search/varchar/equal/row-level-security/seqscan.sql
@@ -7,13 +7,17 @@ CREATE TABLE tags (
 CREATE USER alice NOLOGIN;
 GRANT ALL ON TABLE tags TO alice;
 
-INSERT INTO tags VALUES (1, 'nonexistent', 'PostgreSQL');
-INSERT INTO tags VALUES (2, 'alice', 'Groonga');
-INSERT INTO tags VALUES (3, 'alice', 'groonga');
-INSERT INTO tags VALUES (4, 'alice', 'PGroonga');
+INSERT INTO tags VALUES (1, 'nonexistent', 'GROONGA');
+INSERT INTO tags VALUES (2, 'nonexistent', 'PostgreSQL');
+INSERT INTO tags VALUES (3, 'alice', 'Groonga');
+INSERT INTO tags VALUES (4, 'alice', 'groonga');
+INSERT INTO tags VALUES (5, 'alice', 'PGroonga');
 
 ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
 CREATE POLICY tags_myself ON tags USING (user_name = current_user);
+
+CREATE INDEX pgrn_index ON tags
+ USING pgroonga (name pgroonga_varchar_term_search_ops_v2);
 
 SET enable_seqscan = on;
 SET enable_indexscan = off;
@@ -24,14 +28,14 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT name
   FROM tags
- WHERE name &= 'groonga'
+ WHERE name &= pgroonga_condition('groonga', index_name => 'pgrn_index')
  ORDER BY id
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 \pset format aligned
 
 SELECT name
   FROM tags
- WHERE name &= 'groonga'
+ WHERE name &= pgroonga_condition('groonga', index_name => 'pgrn_index')
  ORDER BY id;
 RESET SESSION AUTHORIZATION;
 


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with content `'PostgreSQL'`. Given the query `name &= 'groonga'`, the RLS check was used but doesn't effect the last result. It's because `'PostgreSQL'` doesn't contain `'groonga'`.

If we add the additional record with `'GROONGA'` that contains `'groonga'` (case insensitive), we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.