### PR TITLE
meson: add support Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           path: ccache
           key: windows-msvc-${{ env.ARTIFACT_ID }}-ccache-${{ hashFiles('src/**') }}
-          restore-keys: cmake-windows-msvc-${{ env.ARTIFACT_ID }}-ccache-
+          restore-keys: windows-msvc-${{ env.ARTIFACT_ID }}-ccache-
       - name: Prepare ccache
         run: |
           choco install ccache
@@ -118,41 +118,100 @@ jobs:
             rm groonga-latest.zip
             mv groonga-* vendor\groonga
           }
-      - name: Run CMake
+      - name: Configure Groonga
         shell: cmd
         run: |
           call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
           cmake ^
-            -B ..\build ^
+            -B vendor\groonga.build ^
             -G Ninja ^
-            -S . ^
+            -S vendor\groonga ^
             -DCMAKE_BUILD_TYPE=RelWithDebInfo ^
-            -DCMAKE_INSTALL_PREFIX="..\pgsql" ^
+            -DCMAKE_INSTALL_PREFIX="vendor\groonga.install" ^
             -DGRN_WITH_LZ4=bundled ^
             -DGRN_WITH_MECAB=bundled ^
             -DGRN_WITH_MESSAGE_PACK=bundled ^
             -DGRN_WITH_MRUBY=yes ^
             -DGRN_WITH_RAPIDJSON=bundled ^
-            -DGRN_WITH_ZSTD=bundled ^
-            -DPGRN_POSTGRESQL_VERSION_MAJOR=${{ matrix.postgresql-version-major }}
-      - name: Build
+            -DGRN_WITH_XXHASH=bundled ^
+            -DGRN_WITH_ZSTD=bundled
+      - name: Build Groonga
         shell: cmd
         run: |
           call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
-          cmake --build ..\build
-      - name: Install
+          cmake --build vendor\groonga.build
+      - name: Install Groonga
+        shell: cmd
         run: |
-          cmake --install ..\build
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          cmake --install vendor\groonga.build
+      - name: Add Groonga to PATH
+        run: |
+          $GROONGA_BIN = "$(Get-Location)\vendor\groonga.install\bin"
+          $env:PATH = "$GROONGA_BIN;$env:PATH"
+          echo "PATH=$env:PATH" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Install Build Tools
+        run: |
+          choco install meson
+          $env:PATH = "C:\Program Files\Meson;$env:PATH"
+          echo "PATH=$env:PATH" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Get-Command meson
+          (Get-Command meson).Source
+          meson --version
+      - name: Install MessagePack
+        run: |
+          vcpkg install msgpack-c:x64-windows
+          $MSGPACK_INSTALL_DIR = "C:\vcpkg\installed\x64-windows"
+          $env:CMAKE_PREFIX_PATH = "$MSGPACK_INSTALL_DIR;$env:CMAKE_PREFIX_PATH"
+          Write-Output "CMAKE_PREFIX_PATH=$env:CMAKE_PREFIX_PATH;" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Add Groonga to CMAKE_PREFIX_PATH
+        run: |
+          $GROONGA_INSTALL_DIR = "$(Get-Location)\vendor\groonga.install"
+          $env:CMAKE_PREFIX_PATH = "$GROONGA_INSTALL_DIR;$env:CMAKE_PREFIX_PATH"
+          Write-Output "CMAKE_PREFIX_PATH=$env:CMAKE_PREFIX_PATH" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Prepare pg_regress for PostgreSQL 17+
+        if: ${{ matrix.postgresql-version-major >= 17 }}
+        run: |
+          # pg_regress.exe depends on libpq.dll and libpq.dll exists
+          # in pgsql\bin\. We add the bin directory to PATH so that
+          # pg_regress.exe can find libpq.dll.
+          # This must run BEFORE meson setup so the dependency is resolved.
+          $PGSQL_BIN = "$(Get-Location)\..\pgsql\bin"
+          $env:PATH = "$PGSQL_BIN;$env:PATH"
+          echo "PATH=$env:PATH" | `
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Configure PGroonga
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          for %%I in (%CD%\..) do set "PARENT_DIR=%%~fI"
+          meson setup ^
+            --wipe ^
+            ..\pgroonga.build ^
+            --prefix="%PARENT_DIR%\pgsql" ^
+            -Dpg_config="%PARENT_DIR%\pgsql\bin\pg_config.exe"
+      - name: Build PGroonga
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          meson compile -C ..\pgroonga.build
+      - name: Install PGroonga
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          meson install -C ..\pgroonga.build
 
       # Upload artifacts
       - name: Package
         run: |
           New-Item artifacts -ItemType Directory
-          cmake `
-            --build ..\build `
-            --target package `
-            --verbose
-          Copy-Item -Path ..\build\*.zip -Destination artifacts
+          Compress-Archive `
+            -Path ..\pgsql\* `
+            -DestinationPath artifacts\pgroonga-${{ matrix.postgresql-version-major }}-windows-x64.zip
           Write-Output "ARTIFACT_BASENAME=$((Get-Item artifacts\*.zip).name)" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: actions/upload-artifact@v6
@@ -168,49 +227,33 @@ jobs:
             --locale=C `
             --pgdata=${Env:PGROONGA_TEST_DATA} `
             --username=${Env:PGROONGA_TEST_USER}
-          Write-Output "max_prepared_transactions = 1" | `
-            Out-File `
-              -FilePath ${Env:PGROONGA_TEST_DATA}\postgresql.conf `
-              -Encoding utf8 `
-              -Append
+          Add-Content `
+            -Path ${Env:PGROONGA_TEST_DATA}\postgresql.conf `
+            -Value "enable_partitionwise_join = on","max_prepared_transactions = 1","random_page_cost = 0" `
+            -Encoding utf8
           ..\pgsql\bin\pg_ctl start `
             --pgdata=${Env:PGROONGA_TEST_DATA}
-      - name: Run regression test
-        # TODO: Remove this when we're PostgreSQL 18 on Windows ready
-        continue-on-error: ${{ matrix.postgresql-version-major == '18' && true || false }}
+      - name: Prepare test files
         run: |
           # TODO: Remove me when Groonga bundles libstemmer
           Remove-Item sql\full-text-search\text\options\token-filters\custom.sql
           # Reduce tests to reduce test time
           Remove-Item sql\compatibility -Recurse -Force
-          ruby test\prepare.rb > schedule
-          $Env:PG_REGRESS_DIFF_OPTS = "-u"
-          if (${{ matrix.postgresql-version-major }} -ge 17) {
-            # pg_regress.exe depends on libpq.dll and libpq.dll exists
-            # in pgsql\bin\. We need to set $Env:PATH or use same
-            # directory to resolve the dependency. We use the same
-            # directory approach here.
-            Copy-Item `
-              -Path ..\pgsql\lib\pgxs\src\test\regress\pg_regress.exe `
-              ..\pgsql\bin\
-          }
-          ..\pgsql\bin\pg_regress `
-            --bindir=..\pgsql\bin `
-            --encoding=${Env:PGROONGA_TEST_ENCODING} `
-            --launcher=test\short-pgappname.bat `
-            --load-extension=pgroonga `
-            --schedule=schedule `
-            --user=${Env:PGROONGA_TEST_USER}
+      - name: Run regression test
+        shell: cmd
+        run: |
+          call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
+          set PGUSER=%PGROONGA_TEST_USER%
+          meson test -C ..\pgroonga.build -v
       - name: Shutdown PostgreSQL for test
         if: always()
         run: |
           ..\pgsql\bin\pg_ctl stop `
             --pgdata=${Env:PGROONGA_TEST_DATA}
       - name: Show diff
-        # TODO: Remove "matrix.postgresql-version-major == '18' ||" when we're PostgreSQL 18 on Windows ready
-        if: matrix.postgresql-version-major == '18' || failure()
+        if: failure()
         run: |
-          Get-Content regression.diffs
+          Get-Content ..\pgroonga.build\regression.diffs
       - uses: actions/checkout@v6
         with:
           repository: pgroonga/benchmark

--- a/meson.build
+++ b/meson.build
@@ -6,9 +6,20 @@ project(
 
 required_groonga_version = '14.1.0'
 
-groonga = dependency('groonga', version: '>= ' + required_groonga_version)
+if host_machine.system() == 'windows'
+  # On Windows, use CMake to find Groonga since pkg-config is not reliably
+  # available.
+  groonga = dependency('Groonga',
+    version: '>= ' + required_groonga_version,
+    method: 'cmake',
+    modules: ['Groonga::libgroonga'])
+else
+  groonga = dependency('groonga', version: '>= ' + required_groonga_version)
+endif
 cc = meson.get_compiler('c')
-libm = cc.find_library('m')
+if host_machine.system() == 'windows'
+  windows = import('windows')
+endif
 
 pg_config_path = get_option('pg_config')
 if pg_config_path == ''
@@ -17,6 +28,9 @@ endif
 pg_config = find_program(pg_config_path)
 pg_includedir_server = run_command(
   pg_config, '--includedir-server', check: true
+).stdout().strip()
+pg_includedir = run_command(
+  pg_config, '--includedir', check: true
 ).stdout().strip()
 pg_pkglibdir = run_command(
   pg_config, '--pkglibdir', check: true
@@ -29,10 +43,26 @@ pg_bindir = run_command(
 ).stdout().strip()
 pg_includedir_extension = pg_includedir_server / 'extension'
 
+pgrn_project_id = meson.project_name()
 pgrn_version = meson.project_version()
+
+pgrn_version_components = pgrn_version.split('.')
+pgrn_rc_config = {
+  'PGRN_VERSION_MAJOR': pgrn_version_components[0],
+  'PGRN_VERSION_MINOR': pgrn_version_components[1],
+  'PGRN_VERSION_MICRO': pgrn_version_components[2],
+  'PGRN_VERSION': pgrn_version,
+  'PGRN_VENDOR': 'The PGroonga Project',
+  'PGRN_DESCRIPTION': 'Super fast and all languages supported full text search index based on Groonga',
+  'PGRN_PROJECT_NAME': 'PGroonga',
+}
+
 pgrn_c_args = [f'-DPGRN_VERSION="@pgrn_version@"']
 if get_option('buildtype').startswith('debug')
   pgrn_c_args += ['-DPGROONGA_DEBUG=1']
+endif
+if host_machine.system() == 'windows'
+  pgrn_c_args += ['/EHsc']
 endif
 
 # Note: Meson's split() is NOT shell-compatible.
@@ -40,17 +70,44 @@ endif
 # For example: 'a "b c" d' becomes ['a', '"b', 'c"', 'd'] instead of ['a', 'b c', 'd'].
 # This works for most PostgreSQL flags but may break with quoted paths containing spaces.
 # Related upstream issue: https://github.com/mesonbuild/meson/issues/15000
-pg_cppflags = run_command(pg_config, '--cppflags', check: true).stdout().strip().split()
-pg_cflags_sl = run_command(pg_config, '--cflags_sl', check: true).stdout().strip().split()
+if host_machine.system() == 'windows'
+  pg_cppflags = []
+  pg_cflags_sl = []
+else
+  pg_cppflags = run_command(pg_config, '--cppflags', check: true).stdout().strip().split()
+  pg_cflags_sl = run_command(pg_config, '--cflags_sl', check: true).stdout().strip().split()
+endif
+
+pg_include_dirs = []
+if host_machine.system() == 'windows'
+  # Windows needs port-specific includes first for platform headers
+  # These provide Windows implementations of Unix headers (netdb.h, etc.)
+  pg_include_dirs += [
+    include_directories(pg_includedir_server / 'port' / 'win32_msvc', is_system: true),
+    include_directories(pg_includedir_server / 'port' / 'win32', is_system: true),
+    include_directories(pg_includedir, is_system: true),
+  ]
+endif
+pg_include_dirs += [
+  include_directories(pg_includedir_server, is_system: true),
+]
 
 postgresql = declare_dependency(
   compile_args: pg_cppflags + pg_cflags_sl,
-  include_directories: [
-    include_directories(pg_includedir_server, is_system: true),
-  ],
+  include_directories: pg_include_dirs,
 )
 
-pgrn_dependencies = [postgresql, groonga, libm]
+pgrn_dependencies = [postgresql, groonga]
+if host_machine.system() == 'windows'
+  # On Windows, extensions must explicitly link against postgres.lib
+  # to access PostgreSQL server functions
+  postgresql_lib = cc.find_library('postgres', dirs: [pg_pkglibdir])
+  pgrn_dependencies += postgresql_lib
+else
+  # On Unix/Linux, link against libm (math library)
+  libm = cc.find_library('m')
+  pgrn_dependencies += libm
+endif
 
 if meson.version().version_compare('>= 0.60.0')
   msgpack = dependency('msgpack-c', 'msgpack', required: get_option('message_pack'))
@@ -68,14 +125,18 @@ if msgpack.found()
   pgrn_dependencies += pgrn_msgpack
 endif
 
-xxhash = dependency('libxxhash', required: get_option('xxhash'))
+xxhash = dependency('libxxhash',
+  required: get_option('xxhash'),
+  fallback: ['xxhash', 'xxhash_dep'])
 if xxhash.found()
   pgrn_dependencies += xxhash
 endif
 
 name_suffix = 'so'
-if host_machine.system() == 'darwin' and \
-   pg_config.version().version_compare('>= 16')
+if host_machine.system() == 'windows'
+  name_suffix = 'dll'
+elif host_machine.system() == 'darwin' and \
+     pg_config.version().version_compare('>= 16')
   name_suffix = 'dylib'
 endif
 
@@ -134,6 +195,16 @@ pgroonga_sources = files(
   'src/pgroonga.c',
 )
 
+if host_machine.system() == 'windows'
+  pgroonga_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga.rc.in',
+      output: 'pgroonga.rc',
+      configuration: pgrn_rc_config + {'PGRN_DLL_NAME': pgrn_project_id}
+    )
+  )
+endif
+
 pgroonga = shared_module('pgroonga',
   pgroonga_sources,
   kwargs: pgrn_module_args,
@@ -142,6 +213,16 @@ pgroonga = shared_module('pgroonga',
 pgroonga_check_sources = files(
   'src/pgroonga-check.c',
 )
+
+if host_machine.system() == 'windows'
+  pgroonga_check_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga-check.rc.in',
+      output: 'pgroonga-check.rc',
+      configuration: pgrn_rc_config + {'PGRN_CHECK_DLL_NAME': pgrn_project_id + '_check'}
+    )
+  )
+endif
 
 pgroonga_check = shared_module('pgroonga_check',
   pgroonga_check_sources,
@@ -152,6 +233,16 @@ pgroonga_database_sources = files(
   'src/pgroonga-database.c',
 )
 
+if host_machine.system() == 'windows'
+  pgroonga_database_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga-database.rc.in',
+      output: 'pgroonga-database.rc',
+      configuration: pgrn_rc_config + {'PGRN_DATABASE_DLL_NAME': pgrn_project_id + '_database'}
+    )
+  )
+endif
+
 pgroonga_database = shared_module('pgroonga_database',
   pgroonga_database_sources,
   kwargs: pgrn_module_args,
@@ -160,6 +251,16 @@ pgroonga_database = shared_module('pgroonga_database',
 pgroonga_wal_applier_sources = files(
   'src/pgroonga-wal-applier.c',
 )
+
+if host_machine.system() == 'windows'
+  pgroonga_wal_applier_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga-wal-applier.rc.in',
+      output: 'pgroonga-wal-applier.rc',
+      configuration: pgrn_rc_config + {'PGRN_WAL_APPLIER_DLL_NAME': pgrn_project_id + '_wal_applier'}
+    )
+  )
+endif
 
 pgroonga_wal_applier = shared_module('pgroonga_wal_applier',
   pgroonga_wal_applier_sources,
@@ -170,6 +271,16 @@ pgroonga_crash_safer_sources = files(
   'src/pgroonga-crash-safer.c',
 )
 
+if host_machine.system() == 'windows'
+  pgroonga_crash_safer_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga-crash-safer.rc.in',
+      output: 'pgroonga-crash-safer.rc',
+      configuration: pgrn_rc_config + {'PGRN_CRASH_SAFER_DLL_NAME': pgrn_project_id + '_crash_safer'}
+    )
+  )
+endif
+
 pgroonga_crash_safer = shared_module('pgroonga_crash_safer',
   pgroonga_crash_safer_sources,
   kwargs: pgrn_module_args,
@@ -179,6 +290,16 @@ pgroonga_standby_maintainer_sources = files(
   'src/pgroonga-standby-maintainer.c',
 )
 
+if host_machine.system() == 'windows'
+  pgroonga_standby_maintainer_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga-standby-maintainer.rc.in',
+      output: 'pgroonga-standby-maintainer.rc',
+      configuration: pgrn_rc_config + {'PGRN_STANDBY_MAINTAINER_DLL_NAME': pgrn_project_id + '_standby_maintainer'}
+    )
+  )
+endif
+
 pgroonga_standby_maintainer = shared_module('pgroonga_standby_maintainer',
   pgroonga_standby_maintainer_sources,
   kwargs: pgrn_module_args,
@@ -187,6 +308,16 @@ pgroonga_standby_maintainer = shared_module('pgroonga_standby_maintainer',
 pgroonga_wal_resource_manager_sources = files(
   'src/pgroonga-wal-resource-manager.c',
 )
+
+if host_machine.system() == 'windows'
+  pgroonga_wal_resource_manager_sources += windows.compile_resources(
+    configure_file(
+      input: 'src/pgroonga-wal-resource-manager.rc.in',
+      output: 'pgroonga-wal-resource-manager.rc',
+      configuration: pgrn_rc_config + {'PGRN_WAL_RESOURCE_MANAGER_DLL_NAME': pgrn_project_id + '_wal_resource_manager'}
+    )
+  )
+endif
 
 pgroonga_wal_resource_manager = shared_module('pgroonga_wal_resource_manager',
   pgroonga_wal_resource_manager_sources,
@@ -429,19 +560,32 @@ install_data(maintainer_scripts,
 
 if get_option('test')
   ruby = find_program('ruby')
+  # For PostgreSQL 17+ on Windows, pg_regress.exe in pgxs depends on libpq.dll
+  # which is in the bin directory. We copy pg_regress.exe to bin in CI,
+  # so search bin directory first for PostgreSQL 17+ on Windows only.
+  if host_machine.system() == 'windows' and pg_config.version().version_compare('>= 17')
+    pg_regress_dirs = [
+      pg_bindir,
+      pg_pkglibdir / 'pgxs/src/test/regress',
+    ]
+  else
+    pg_regress_dirs = [
+      pg_pkglibdir / 'pgxs/src/test/regress',
+      pg_bindir,
+    ]
+  endif
   pg_regress = find_program(
     'pg_regress',
-    dirs: [pg_pkglibdir / 'pgxs/src/test/regress']
+    dirs: pg_regress_dirs
   )
 
-  schedule = meson.current_build_dir() / 'schedule'
   prepare_test = custom_target(
     'prepare',
     output: 'schedule',
     command: [
       ruby,
       meson.current_source_dir() / 'test' / 'prepare.rb',
-      schedule
+      '@OUTPUT@'
     ],
     env: {
       'BUILD_DIR': meson.current_build_dir(),
@@ -449,6 +593,12 @@ if get_option('test')
     build_always_stale: true
   )
 
+  schedule = prepare_test.full_path()
+  if host_machine.system() == 'windows'
+    launcher = meson.current_source_dir() / 'test' / 'short-pgappname.bat'
+  else
+    launcher = meson.current_source_dir() / 'test' / 'short-pgappname'
+  endif
   test('regression',
     pg_regress,
     args: [
@@ -456,7 +606,7 @@ if get_option('test')
       '--dlpath', meson.current_build_dir(),
       '--inputdir', meson.current_source_dir(),
       '--outputdir', meson.current_build_dir(),
-      '--launcher', meson.current_source_dir() / 'test' / 'short-pgappname',
+      '--launcher', launcher,
       '--load-extension', meson.project_name(),
       '--schedule', schedule
     ],

--- a/subprojects/xxhash.wrap
+++ b/subprojects/xxhash.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = xxHash-0.8.3
+source_url = https://github.com/Cyan4973/xxHash/archive/v0.8.3.tar.gz
+source_filename = xxHash-0.8.3.tar.gz
+source_hash = aae608dfe8213dfd05d909a57718ef82f30722c392344583d3f39050c7f29a80
+patch_filename = xxhash_0.8.3-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/xxhash_0.8.3-2/get_patch
+patch_hash = c7f78fc2d08ec21ff1bae928d7bdcddb42713a07d9d973a885c59ea7f8cf6bc8
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/xxhash_0.8.3-2/xxHash-0.8.3.tar.gz
+wrapdb_version = 0.8.3-2
+
+[provide]
+libxxhash = xxhash_dep


### PR DESCRIPTION
GitHub: GH-490

This PR enables building PGroonga with Meson on
Windows by addressing platform-specific compilation.