### PR TITLE
fix full-text-search/varchar/match-condition-v2: fix row level security tests

### DIFF
--- a/expected/full-text-search/varchar/match-condition-v2/row-level-security/bitmapscan.out
+++ b/expected/full-text-search/varchar/match-condition-v2/row-level-security/bitmapscan.out
@@ -8,7 +8,7 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'nonexistent', 'Rroonga is the Ruby bindings of GROONGA.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
   (3, 'alice', 'Groonga is fast full text search engine.');
 INSERT INTO memos VALUES

--- a/expected/full-text-search/varchar/match-condition-v2/row-level-security/indexscan.out
+++ b/expected/full-text-search/varchar/match-condition-v2/row-level-security/indexscan.out
@@ -8,7 +8,7 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'nonexistent', 'Rroonga is the Ruby bindings of GROONGA.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
   (3, 'alice', 'Groonga is fast full text search engine.');
 INSERT INTO memos VALUES

--- a/expected/full-text-search/varchar/match-condition-v2/row-level-security/seqscan.out
+++ b/expected/full-text-search/varchar/match-condition-v2/row-level-security/seqscan.out
@@ -8,7 +8,7 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'nonexistent', 'Rroonga is the Ruby bindings of GROONGA.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
   (3, 'alice', 'Groonga is fast full text search engine.');
 INSERT INTO memos VALUES

--- a/sql/full-text-search/varchar/match-condition-v2/row-level-security/bitmapscan.sql
+++ b/sql/full-text-search/varchar/match-condition-v2/row-level-security/bitmapscan.sql
@@ -10,7 +10,7 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'nonexistent', 'Rroonga is the Ruby bindings of GROONGA.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
   (3, 'alice', 'Groonga is fast full text search engine.');
 INSERT INTO memos VALUES

--- a/sql/full-text-search/varchar/match-condition-v2/row-level-security/indexscan.sql
+++ b/sql/full-text-search/varchar/match-condition-v2/row-level-security/indexscan.sql
@@ -10,7 +10,7 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'nonexistent', 'Rroonga is the Ruby bindings of GROONGA.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
   (3, 'alice', 'Groonga is fast full text search engine.');
 INSERT INTO memos VALUES

--- a/sql/full-text-search/varchar/match-condition-v2/row-level-security/seqscan.sql
+++ b/sql/full-text-search/varchar/match-condition-v2/row-level-security/seqscan.sql
@@ -10,7 +10,7 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'nonexistent', 'Rroonga is the Ruby bindings of GROONGA.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
   (3, 'alice', 'Groonga is fast full text search engine.');
 INSERT INTO memos VALUES


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with content `'PostgreSQL is a RDBMS.'`. Given the query `content &@ pgroonga_condition('Groonga', index_name => 'pgrn_index')`, the RLS check is used but does not effect the last result. It's because `'PostgreSQL is a RDBMS.'` doesn't match `'Groonga'`.

If we add an additional record with `'Rroonga is the Ruby bindings of Groonga'` that matches `'Groonga'`(case insensitive), we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.