### PR TITLE
test: revert GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR in test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -68,6 +68,7 @@ jobs:
           download_cache_dir="/tmp/cache/language-models"
           mkdir -p "${download_cache_dir}"
           echo "GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR=${download_cache_dir}" >> ${GITHUB_ENV}
+          echo "PGRN_LANGUAGE_MODEL_TEST=yes" >> ${GITHUB_ENV}
       - name: Cache language models
         if: matrix.groonga-main == 'yes'
         uses: actions/cache@v4

--- a/expected/function/language-model-vectorize/huggingface.out
+++ b/expected/function/language-model-vectorize/huggingface.out
@@ -1,5 +1,5 @@
--- Only test when `GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR` is set.
-\getenv language_model_test GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
 SELECT NOT :{?language_model_test} AS omit \gset
 \if :omit
   \quit

--- a/expected/function/language-model-vectorize/huggingface_1.out
+++ b/expected/function/language-model-vectorize/huggingface_1.out
@@ -1,5 +1,5 @@
--- Only test when `GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR` is set.
-\getenv language_model_test GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
 SELECT NOT :{?language_model_test} AS omit \gset
 \if :omit
   \quit

--- a/expected/function/language-model-vectorize/huggingface_2.out
+++ b/expected/function/language-model-vectorize/huggingface_2.out
@@ -1,5 +1,5 @@
--- Only test when `GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR` is set.
-\getenv language_model_test GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
 invalid command \getenv
 SELECT NOT :{?language_model_test} AS omit \gset
 \if :omit

--- a/sql/function/language-model-vectorize/huggingface.sql
+++ b/sql/function/language-model-vectorize/huggingface.sql
@@ -1,5 +1,5 @@
--- Only test when `GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR` is set.
-\getenv language_model_test GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
 SELECT NOT :{?language_model_test} AS omit \gset
 \if :omit
   \quit


### PR DESCRIPTION
`\getenv` gets a client side environment variable not a server side's one. So we don't need to use the same variable name and same variable value.