### PR TITLE
Add support for semantic search

### DIFF
--- a/data/pgroonga--4.0.4--4.0.5.sql
+++ b/data/pgroonga--4.0.4--4.0.5.sql
@@ -6,3 +6,27 @@ CREATE OR REPLACE FUNCTION pgroonga_language_model_vectorize(model_name cstring,
 	LANGUAGE C
 	STRICT
 	PARALLEL SAFE;
+
+CREATE FUNCTION pgroonga_similar_text_condition
+	(query text, condition pgroonga_condition)
+	RETURNS bool
+	AS 'MODULE_PATHNAME', 'pgroonga_similar_text_condition'
+	LANGUAGE C
+	IMMUTABLE
+	STRICT
+	LEAKPROOF
+	PARALLEL SAFE
+	COST 10000;
+
+CREATE OPERATOR &@* (
+	PROCEDURE = pgroonga_similar_text_condition,
+	LEFTARG = text,
+	RIGHTARG = pgroonga_condition,
+	RESTRICT = contsel,
+	JOIN = contjoinsel
+);
+
+CREATE OPERATOR CLASS pgroonga_text_semantic_search_ops_v2 FOR TYPE text
+	USING pgroonga AS
+		OPERATOR 29 &@*,
+		OPERATOR 48 &@* (text, pgroonga_condition);

--- a/data/pgroonga--4.0.5--4.0.4.sql
+++ b/data/pgroonga--4.0.5--4.0.4.sql
@@ -1,3 +1,7 @@
 -- Downgrade SQL
 
 DROP FUNCTION IF EXISTS pgroonga_language_model_vectorize;
+
+DROP OPERATOR FAMILY pgroonga_text_semantic_search_ops_v2 USING pgroonga;
+DROP OPERATOR &@* (text, pgroonga_condition);
+DROP FUNCTION pgroonga_similar_text_condition;

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -1241,6 +1241,25 @@ CREATE OPERATOR &@* (
 	JOIN = contjoinsel
 );
 
+CREATE FUNCTION pgroonga_similar_text_condition
+	(query text, condition pgroonga_condition)
+	RETURNS bool
+	AS 'MODULE_PATHNAME', 'pgroonga_similar_text_condition'
+	LANGUAGE C
+	IMMUTABLE
+	STRICT
+	LEAKPROOF
+	PARALLEL SAFE
+	COST 10000;
+
+CREATE OPERATOR &@* (
+	PROCEDURE = pgroonga_similar_text_condition,
+	LEFTARG = text,
+	RIGHTARG = pgroonga_condition,
+	RESTRICT = contsel,
+	JOIN = contjoinsel
+);
+
 CREATE FUNCTION pgroonga_prefix_text(text, text)
 	RETURNS bool
 	AS 'MODULE_PATHNAME', 'pgroonga_prefix_text'
@@ -2474,6 +2493,13 @@ CREATE OPERATOR CLASS pgroonga_text_array_full_text_search_ops_v2
 		OPERATOR 34 &@~ (text[], pgroonga_full_text_search_condition_with_scorers),
 		OPERATOR 42 &@ (text[], pgroonga_condition),
 		OPERATOR 43 &@~ (text[], pgroonga_condition);
+
+
+CREATE OPERATOR CLASS pgroonga_text_semantic_search_ops_v2 FOR TYPE text
+	USING pgroonga AS
+		OPERATOR 29 &@*,
+		OPERATOR 48 &@* (text, pgroonga_condition);
+
 
 CREATE OPERATOR CLASS pgroonga_text_term_search_ops_v2 FOR TYPE text
 	USING pgroonga AS

--- a/expected/semantic-search/text/similar-condition-v2/bitmapscan.out
+++ b/expected/semantic-search/text/similar-condition-v2/bitmapscan.out
@@ -1,0 +1,47 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (pgroonga_score(tableoid, ctid)) DESC
+   ->  Bitmap Heap Scan on memos
+         Recheck Cond: (content &@* '("What is a MySQL alternative?",,,,,,)'::pgroonga_condition)
+         ->  Bitmap Index Scan on pgrn_index
+               Index Cond: (content &@* '("What is a MySQL alternative?",,,,,,)'::pgroonga_condition)
+(6 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+ id |                        content                        
+----+-------------------------------------------------------
+  1 | PostgreSQL is a RDBMS.
+  3 | PGroonga is a PostgreSQL extension that uses Groonga.
+  2 | Groonga is fast full text search engine.
+(3 rows)
+
+DROP TABLE memos;

--- a/expected/semantic-search/text/similar-condition-v2/bitmapscan_1.out
+++ b/expected/semantic-search/text/similar-condition-v2/bitmapscan_1.out
@@ -1,0 +1,5 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-condition-v2/bitmapscan_2.out
+++ b/expected/semantic-search/text/similar-condition-v2/bitmapscan_2.out
@@ -1,0 +1,6 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+invalid command \getenv
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-condition-v2/indexscan.out
+++ b/expected/semantic-search/text/similar-condition-v2/indexscan.out
@@ -1,0 +1,45 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (pgroonga_score(tableoid, ctid)) DESC
+   ->  Index Scan using pgrn_index on memos
+         Index Cond: (content &@* '("What is a MySQL alternative?",,,,,,)'::pgroonga_condition)
+(4 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+ id |                        content                        
+----+-------------------------------------------------------
+  1 | PostgreSQL is a RDBMS.
+  3 | PGroonga is a PostgreSQL extension that uses Groonga.
+  2 | Groonga is fast full text search engine.
+(3 rows)
+
+DROP TABLE memos;

--- a/expected/semantic-search/text/similar-condition-v2/indexscan_1.out
+++ b/expected/semantic-search/text/similar-condition-v2/indexscan_1.out
@@ -1,0 +1,5 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-condition-v2/indexscan_2.out
+++ b/expected/semantic-search/text/similar-condition-v2/indexscan_2.out
@@ -1,0 +1,6 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+invalid command \getenv
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-v2/bitmapscan.out
+++ b/expected/semantic-search/text/similar-v2/bitmapscan.out
@@ -1,0 +1,47 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
+ Sort
+   Sort Key: (pgroonga_score(tableoid, ctid)) DESC
+   ->  Bitmap Heap Scan on memos
+         Recheck Cond: (content &@* 'What is a MySQL alternative?'::text)
+         ->  Bitmap Index Scan on pgrn_index
+               Index Cond: (content &@* 'What is a MySQL alternative?'::text)
+(6 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+ id |                        content                        
+----+-------------------------------------------------------
+  1 | PostgreSQL is a RDBMS.
+  3 | PGroonga is a PostgreSQL extension that uses Groonga.
+  2 | Groonga is fast full text search engine.
+(3 rows)
+
+DROP TABLE memos;

--- a/expected/semantic-search/text/similar-v2/bitmapscan_1.out
+++ b/expected/semantic-search/text/similar-v2/bitmapscan_1.out
@@ -1,0 +1,5 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-v2/bitmapscan_2.out
+++ b/expected/semantic-search/text/similar-v2/bitmapscan_2.out
@@ -1,0 +1,6 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+invalid command \getenv
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-v2/indexscan.out
+++ b/expected/semantic-search/text/similar-v2/indexscan.out
@@ -1,0 +1,45 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Sort
+   Sort Key: (pgroonga_score(tableoid, ctid)) DESC
+   ->  Index Scan using pgrn_index on memos
+         Index Cond: (content &@* 'What is a MySQL alternative?'::text)
+(4 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+ id |                        content                        
+----+-------------------------------------------------------
+  1 | PostgreSQL is a RDBMS.
+  3 | PGroonga is a PostgreSQL extension that uses Groonga.
+  2 | Groonga is fast full text search engine.
+(3 rows)
+
+DROP TABLE memos;

--- a/expected/semantic-search/text/similar-v2/indexscan_1.out
+++ b/expected/semantic-search/text/similar-v2/indexscan_1.out
@@ -1,0 +1,5 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-v2/indexscan_2.out
+++ b/expected/semantic-search/text/similar-v2/indexscan_2.out
@@ -1,0 +1,6 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+invalid command \getenv
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/sql/semantic-search/text/similar-condition-v2/bitmapscan.sql
+++ b/sql/semantic-search/text/similar-condition-v2/bitmapscan.sql
@@ -1,0 +1,37 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+DROP TABLE memos;

--- a/sql/semantic-search/text/similar-condition-v2/indexscan.sql
+++ b/sql/semantic-search/text/similar-condition-v2/indexscan.sql
@@ -1,0 +1,37 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+DROP TABLE memos;

--- a/sql/semantic-search/text/similar-v2/bitmapscan.sql
+++ b/sql/semantic-search/text/similar-v2/bitmapscan.sql
@@ -1,0 +1,37 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+DROP TABLE memos;

--- a/sql/semantic-search/text/similar-v2/indexscan.sql
+++ b/sql/semantic-search/text/similar-v2/indexscan.sql
@@ -1,0 +1,37 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES (3, 'PGroonga is a PostgreSQL extension that uses Groonga.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF');
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* 'What is a MySQL alternative?'
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+DROP TABLE memos;

--- a/src/pgrn-column-name.h
+++ b/src/pgrn-column-name.h
@@ -39,6 +39,8 @@ PGrnColumnNameCheckSize(size_t size, const char *tag)
 static inline size_t
 PGrnColumnNameEncodeUTF8WithSize(const char *name,
 								 size_t nameSize,
+								 const char *suffix,
+								 size_t suffixSize,
 								 char *encodedName)
 {
 	const char *tag = "[column-name][encode][utf8]";
@@ -86,6 +88,15 @@ PGrnColumnNameEncodeUTF8WithSize(const char *name,
 		current += length;
 	}
 
+	{
+		size_t i;
+		for (i = 0; i < suffixSize; i++)
+		{
+			*encodedCurrent++ = suffix[i];
+			encodedNameSize++;
+		}
+	}
+
 	*encodedCurrent = '\0';
 
 	return encodedNameSize;
@@ -94,6 +105,8 @@ PGrnColumnNameEncodeUTF8WithSize(const char *name,
 static inline size_t
 PGrnColumnNameEncodeWithSize(const char *name,
 							 size_t nameSize,
+							 const char *suffix,
+							 size_t suffixSize,
 							 char *encodedName)
 {
 	const char *tag = "[column-name][encode]";
@@ -103,7 +116,8 @@ PGrnColumnNameEncodeWithSize(const char *name,
 	size_t encodedNameSize = 0;
 
 	if (GRN_CTX_GET_ENCODING(ctx) == GRN_ENC_UTF8)
-		return PGrnColumnNameEncodeUTF8WithSize(name, nameSize, encodedName);
+		return PGrnColumnNameEncodeUTF8WithSize(
+			name, nameSize, suffix, suffixSize, encodedName);
 
 	current = name;
 	end = name + nameSize;
@@ -141,6 +155,15 @@ PGrnColumnNameEncodeWithSize(const char *name,
 		current++;
 	}
 
+	{
+		size_t i;
+		for (i = 0; i < suffixSize; i++)
+		{
+			*encodedCurrent++ = suffix[i];
+			encodedNameSize++;
+		}
+	}
+
 	*encodedCurrent = '\0';
 
 	return encodedNameSize;
@@ -149,7 +172,16 @@ PGrnColumnNameEncodeWithSize(const char *name,
 static inline size_t
 PGrnColumnNameEncode(const char *name, char *encodedName)
 {
-	return PGrnColumnNameEncodeWithSize(name, strlen(name), encodedName);
+	return PGrnColumnNameEncodeWithSize(
+		name, strlen(name), NULL, 0, encodedName);
+}
+
+static inline size_t
+PGrnCodeColumnNameEncode(const char *name, char *encodedName)
+{
+	const char *suffix = "_code";
+	return PGrnColumnNameEncodeWithSize(
+		name, strlen(name), suffix, strlen(suffix), encodedName);
 }
 
 static inline size_t

--- a/src/pgrn-create.h
+++ b/src/pgrn-create.h
@@ -21,6 +21,7 @@ typedef struct PGrnCreateData
 	bool forFullTextSearch;
 	bool forRegexpSearch;
 	bool forPrefixSearch;
+	bool forSemanticSearch;
 	grn_id attributeTypeID;
 	unsigned char attributeFlags;
 } PGrnCreateData;

--- a/src/pgrn-groonga.c
+++ b/src/pgrn-groonga.c
@@ -14,6 +14,8 @@
 bool PGrnIsLZ4Available;
 bool PGrnIsZlibAvailable;
 bool PGrnIsZstdAvailable;
+bool PGrnIsLlamaCppAvailable;
+bool PGrnIsFaissAvailable;
 bool PGrnIsTemporaryIndexSearchAvailable;
 
 static struct PGrnBuffers *buffers = &PGrnBuffers;
@@ -55,6 +57,23 @@ PGrnInitializeGroongaInformation(void)
 	GRN_BULK_REWIND(&grnIsSupported);
 	grn_obj_get_info(ctx, NULL, GRN_INFO_SUPPORT_ZSTD, &grnIsSupported);
 	PGrnIsZstdAvailable = (GRN_BOOL_VALUE(&grnIsSupported));
+
+#if GRN_VERSION_OR_LATER(15, 1, 8)
+	GRN_BULK_REWIND(&grnIsSupported);
+	grn_obj_get_info(ctx, NULL, GRN_INFO_SUPPORT_LLAMA_CPP, &grnIsSupported);
+	PGrnIsLlamaCppAvailable = (GRN_BOOL_VALUE(&grnIsSupported));
+#else
+	PGrnIsLlamaCppAvailable = false;
+#endif
+
+#if GRN_VERSION_OR_LATER(15, 1, 8)
+	GRN_BULK_REWIND(&grnIsSupported);
+	grn_obj_get_info(ctx, NULL, GRN_INFO_SUPPORT_FAISS, &grnIsSupported);
+	PGrnIsFaissAvailable = (GRN_BOOL_VALUE(&grnIsSupported));
+#else
+	PGrnIsFaissAvailable = false;
+#endif
+
 	PGrnIsTemporaryIndexSearchAvailable = IsTemporaryIndexSearchAvailable();
 
 	GRN_OBJ_FIN(ctx, &grnIsSupported);

--- a/src/pgrn-groonga.h
+++ b/src/pgrn-groonga.h
@@ -13,6 +13,8 @@
 extern bool PGrnIsLZ4Available;
 extern bool PGrnIsZlibAvailable;
 extern bool PGrnIsZstdAvailable;
+extern bool PGrnIsLlamaCppAvailable;
+extern bool PGrnIsFaissAvailable;
 extern bool PGrnIsTemporaryIndexSearchAvailable;
 
 void PGrnInitializeGroongaInformation(void);
@@ -136,7 +138,8 @@ PGrnLookupColumnWithSize(grn_obj *table,
 	size_t columnNameSize;
 	grn_obj *column;
 
-	columnNameSize = PGrnColumnNameEncodeWithSize(name, nameSize, columnName);
+	columnNameSize =
+		PGrnColumnNameEncodeWithSize(name, nameSize, NULL, 0, columnName);
 	column = grn_obj_column(ctx, table, columnName, columnNameSize);
 	if (!column)
 	{

--- a/src/pgrn-options.h
+++ b/src/pgrn-options.h
@@ -10,7 +10,8 @@ typedef enum
 	PGRN_OPTION_USE_CASE_UNKNOWN,
 	PGRN_OPTION_USE_CASE_FULL_TEXT_SEARCH,
 	PGRN_OPTION_USE_CASE_REGEXP_SEARCH,
-	PGRN_OPTION_USE_CASE_PREFIX_SEARCH
+	PGRN_OPTION_USE_CASE_PREFIX_SEARCH,
+	PGRN_OPTION_USE_CASE_SEMANTIC_SEARCH,
 } PGrnOptionUseCase;
 
 typedef struct PGrnResolvedOptions
@@ -21,6 +22,7 @@ typedef struct PGrnResolvedOptions
 	grn_obj *plugins;
 	grn_table_flags lexiconType;
 	grn_column_flags indexFlags;
+	const char *modelName;
 } PGrnResolvedOptions;
 
 void PGrnInitializeOptions(void);

--- a/src/pgroonga.h
+++ b/src/pgroonga.h
@@ -107,8 +107,10 @@
 #define PGrnEqualQueryConditionStrategyV2Number 46
 /* operator &~ with pgroonga_condition. */
 #define PGrnRegexpConditionStrategyV2Number 47
+/* operator &@* with pgroonga_condition. */
+#define PGrnSimilarConditionStrategyV2Number 48
 
-#define PGRN_N_STRATEGIES PGrnRegexpConditionStrategyV2Number
+#define PGRN_N_STRATEGIES PGrnSimilarConditionStrategyV2Number
 
 extern grn_ctx PGrnContext;
 static grn_ctx *ctx = &PGrnContext;

--- a/test/run-sql-test.sh
+++ b/test/run-sql-test.sh
@@ -45,9 +45,9 @@ done
 
 meson compile -C ${BUILD_DIR}
 if [ "${NEED_SUDO:-no}" = "yes" ]; then
-  sudo -H meson install -C ${BUILD_DIR} --no-rebuild
+  sudo -H meson install -C ${BUILD_DIR} --no-rebuild > /dev/null
 else
-  meson install -C ${BUILD_DIR} --no-rebuild
+  meson install -C ${BUILD_DIR} --no-rebuild > /dev/null
 fi
 PG_REGRESS_DIFF_OPTS="-u"
 if diff --help | grep -q color; then


### PR DESCRIPTION
This is an experimental feature. API and DB schema may be changed.

* Add `text &@* pgroogna_condition`
* Add `pgroonga_text_semantic_search_ops_v2`
* This requires Groonga 1.5.8 or later
* This requires `plugins = 'language_model/knn'`
* `pgroonga_score()` returns [0.0,1.0] and 1.0 is more similar than 0.0