### PR TITLE
test full-text-search/varchar/match-fts-condition-v2: fix row level security tests

### DIFF
--- a/expected/full-text-search/varchar/match-fts-condition-v2/row-level-security/bitmapscan.out
+++ b/expected/full-text-search/varchar/match-fts-condition-v2/row-level-security/bitmapscan.out
@@ -8,9 +8,11 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'alice', 'Groonga is fast full text search engine.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
-  (3, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+  (3, 'alice', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES
+  (4, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);
 CREATE INDEX pgrn_index ON memos
@@ -46,8 +48,8 @@ SELECT id, content, pgroonga_score(tableoid, ctid)
         'pgrn_index')::pgroonga_full_text_search_condition_with_scorers;
  id |                        content                        | pgroonga_score 
 ----+-------------------------------------------------------+----------------
-  2 | Groonga is fast full text search engine.              |              1
-  3 | PGroonga is a PostgreSQL extension that uses Groonga. |              1
+  3 | Groonga is fast full text search engine.              |              1
+  4 | PGroonga is a PostgreSQL extension that uses Groonga. |              1
 (2 rows)
 
 RESET SESSION AUTHORIZATION;

--- a/expected/full-text-search/varchar/match-fts-condition-v2/row-level-security/indexscan.out
+++ b/expected/full-text-search/varchar/match-fts-condition-v2/row-level-security/indexscan.out
@@ -8,9 +8,11 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'alice', 'Groonga is fast full text search engine.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
-  (3, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+  (3, 'alice', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES
+  (4, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);
 CREATE INDEX pgrn_index ON memos
@@ -44,8 +46,8 @@ SELECT id, content, pgroonga_score(tableoid, ctid)
         'pgrn_index')::pgroonga_full_text_search_condition_with_scorers;
  id |                        content                        | pgroonga_score 
 ----+-------------------------------------------------------+----------------
-  2 | Groonga is fast full text search engine.              |              1
-  3 | PGroonga is a PostgreSQL extension that uses Groonga. |              1
+  3 | Groonga is fast full text search engine.              |              1
+  4 | PGroonga is a PostgreSQL extension that uses Groonga. |              1
 (2 rows)
 
 RESET SESSION AUTHORIZATION;

--- a/expected/full-text-search/varchar/match-fts-condition-v2/row-level-security/seqscan.out
+++ b/expected/full-text-search/varchar/match-fts-condition-v2/row-level-security/seqscan.out
@@ -8,9 +8,11 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'alice', 'Groonga is fast full text search engine.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
-  (3, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+  (3, 'alice', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES
+  (4, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);
 CREATE INDEX pgrn_index ON memos
@@ -43,8 +45,8 @@ SELECT id, content, pgroonga_score(tableoid, ctid)
         'pgrn_index')::pgroonga_full_text_search_condition_with_scorers;
  id |                        content                        | pgroonga_score 
 ----+-------------------------------------------------------+----------------
-  2 | Groonga is fast full text search engine.              |              0
-  3 | PGroonga is a PostgreSQL extension that uses Groonga. |              0
+  3 | Groonga is fast full text search engine.              |              0
+  4 | PGroonga is a PostgreSQL extension that uses Groonga. |              0
 (2 rows)
 
 RESET SESSION AUTHORIZATION;

--- a/sql/full-text-search/varchar/match-fts-condition-v2/row-level-security/bitmapscan.sql
+++ b/sql/full-text-search/varchar/match-fts-condition-v2/row-level-security/bitmapscan.sql
@@ -10,9 +10,11 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'alice', 'Groonga is fast full text search engine.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
-  (3, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+  (3, 'alice', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES
+  (4, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);

--- a/sql/full-text-search/varchar/match-fts-condition-v2/row-level-security/indexscan.sql
+++ b/sql/full-text-search/varchar/match-fts-condition-v2/row-level-security/indexscan.sql
@@ -10,9 +10,11 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'alice', 'Groonga is fast full text search engine.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
-  (3, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+  (3, 'alice', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES
+  (4, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);

--- a/sql/full-text-search/varchar/match-fts-condition-v2/row-level-security/seqscan.sql
+++ b/sql/full-text-search/varchar/match-fts-condition-v2/row-level-security/seqscan.sql
@@ -10,9 +10,11 @@ GRANT ALL ON TABLE memos TO alice;
 INSERT INTO memos VALUES
   (1, 'nonexistent', 'PostgreSQL is a RDBMS.');
 INSERT INTO memos VALUES
-  (2, 'alice', 'Groonga is fast full text search engine.');
+  (2, 'nonexistent', 'Rroonga is the Ruby bindings of Groonga.');
 INSERT INTO memos VALUES
-  (3, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
+  (3, 'alice', 'Groonga is fast full text search engine.');
+INSERT INTO memos VALUES
+  (4, 'alice', 'PGroonga is a PostgreSQL extension that uses Groonga.');
 
 ALTER TABLE memos ENABLE ROW LEVEL SECURITY;
 CREATE POLICY memos_myself ON memos USING (user_name = current_user);


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with content `'PostgreSQL is a RDBMS.'`. Given the query `'content &@ ('Groonga', NULL, NULL, 'pgrn_index')::pgroonga_full_text_search_condition_with_scorers'`, the RLS check is used but does not effect the last result. It's because `'PostgreSQL is a RDBMS.'` doesn't match the above query's condition.

If we add an additional record with `'Rroonga is the Ruby bindings that uses Groonga.'` that matches the above query's condition, we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.