### PR TITLE
ci: workaround for dependency package install failure

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -91,7 +91,7 @@ pgroonga_package=$(basename $(ls ${packages_dir}/*-pgroonga-*.rpm | head -n1) | 
                      sed -e 's/-pgroonga-.*$/-pgroonga/g')
 postgresql_version=$(echo ${pgroonga_package} | grep -E -o '[0-9.]+')
 
-# This condition is workaround.
+# TODO: This condition is workaround.
 # We can remove when the following issue resolved.
 # https://github.com/pgdg-packaging/pgdg-rpms/issues/105
 if [ "${os}" = "almalinux" ] && [ ${major_version} = "10" ]; then


### PR DESCRIPTION
Fix: GH-881

This is workaround.

Currently, installation of pgbackrest package is failure cause of https://github.com/pgdg-packaging/pgdg-rpms/issues/105.
postgresql*-contrib weak dependency pgbackrest.
But even if pgbackrest does not install, have no impact on executing PGroonga's tests.

Therefore, we disable EPEL repository when install postgresql*-contrib.
The pgbackrest package depends on libssh2, which is only available from the EPEL repository.
As a result, pgbackrest is installed only when EPEL is enabled.

If we disable EPEL repository, have no impact on installing postgresql*-contrib.
Because The installation of postgresql*-contrib use EPEL repository only when pgbackrest installed. 
Also, postgresql*-contrib works correctly even if pgbackrest does not installed.
because pgbackrest is weak dependency.

Tests are all passed by this work around as below.
https://github.com/komainu8/pgroonga/actions/runs/18830781666/job/53726404046