### PR TITLE
fix full-text-search/text-array/match-v2: fix row level security tests

### DIFF
--- a/expected/full-text-search/text-array/match-v2/row-level-security/bitmapscan.out
+++ b/expected/full-text-search/text-array/match-v2/row-level-security/bitmapscan.out
@@ -32,24 +32,23 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga'
+ WHERE contents &@ 'PostgreSQL'
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 QUERY PLAN
 Bitmap Heap Scan on memos
-  Recheck Cond: (contents &@ 'Groonga'::text)
+  Recheck Cond: (contents &@ 'PostgreSQL'::text)
   Filter: (user_name = CURRENT_USER)
   ->  Bitmap Index Scan on pgroonga_memos_index
-        Index Cond: (contents &@ 'Groonga'::text)
+        Index Cond: (contents &@ 'PostgreSQL'::text)
 (5 rows)
 \pset format aligned
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga';
+ WHERE contents &@ 'PostgreSQL';
  id |                                                         contents                                                         
 ----+--------------------------------------------------------------------------------------------------------------------------
-  2 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
   3 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
-(2 rows)
+(1 row)
 
 RESET SESSION AUTHORIZATION;
 DROP TABLE memos;

--- a/expected/full-text-search/text-array/match-v2/row-level-security/indexscan.out
+++ b/expected/full-text-search/text-array/match-v2/row-level-security/indexscan.out
@@ -32,22 +32,21 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga'
+ WHERE contents &@ 'PostgreSQL'
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 QUERY PLAN
 Index Scan using pgroonga_memos_index on memos
-  Index Cond: (contents &@ 'Groonga'::text)
+  Index Cond: (contents &@ 'PostgreSQL'::text)
   Filter: (user_name = CURRENT_USER)
 (3 rows)
 \pset format aligned
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga';
+ WHERE contents &@ 'PostgreSQL';
  id |                                                         contents                                                         
 ----+--------------------------------------------------------------------------------------------------------------------------
-  2 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
   3 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
-(2 rows)
+(1 row)
 
 RESET SESSION AUTHORIZATION;
 DROP TABLE memos;

--- a/expected/full-text-search/text-array/match-v2/row-level-security/seqscan.out
+++ b/expected/full-text-search/text-array/match-v2/row-level-security/seqscan.out
@@ -30,21 +30,20 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga'
+ WHERE contents &@ 'PostgreSQL'
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 QUERY PLAN
 Seq Scan on memos
-  Filter: ((user_name = CURRENT_USER) AND (contents &@ 'Groonga'::text))
+  Filter: ((user_name = CURRENT_USER) AND (contents &@ 'PostgreSQL'::text))
 (2 rows)
 \pset format aligned
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga';
+ WHERE contents &@ 'PostgreSQL';
  id |                                                         contents                                                         
 ----+--------------------------------------------------------------------------------------------------------------------------
-  2 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
   3 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
-(2 rows)
+(1 row)
 
 RESET SESSION AUTHORIZATION;
 DROP TABLE memos;

--- a/sql/full-text-search/text-array/match-v2/row-level-security/bitmapscan.sql
+++ b/sql/full-text-search/text-array/match-v2/row-level-security/bitmapscan.sql
@@ -38,13 +38,13 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga'
+ WHERE contents &@ 'PostgreSQL'
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 \pset format aligned
 
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga';
+ WHERE contents &@ 'PostgreSQL';
 RESET SESSION AUTHORIZATION;
 
 DROP TABLE memos;

--- a/sql/full-text-search/text-array/match-v2/row-level-security/indexscan.sql
+++ b/sql/full-text-search/text-array/match-v2/row-level-security/indexscan.sql
@@ -38,13 +38,13 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga'
+ WHERE contents &@ 'PostgreSQL'
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 \pset format aligned
 
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga';
+ WHERE contents &@ 'PostgreSQL';
 RESET SESSION AUTHORIZATION;
 
 DROP TABLE memos;

--- a/sql/full-text-search/text-array/match-v2/row-level-security/seqscan.sql
+++ b/sql/full-text-search/text-array/match-v2/row-level-security/seqscan.sql
@@ -35,13 +35,13 @@ SET SESSION AUTHORIZATION alice;
 EXPLAIN (COSTS OFF)
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga'
+ WHERE contents &@ 'PostgreSQL'
 \g |sed -r -e "s/\(CURRENT_USER\)::text/CURRENT_USER/g"
 \pset format aligned
 
 SELECT id, contents
   FROM memos
- WHERE contents &@ 'Groonga';
+ WHERE contents &@ 'PostgreSQL';
 RESET SESSION AUTHORIZATION;
 
 DROP TABLE memos;


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with contents `ARRAY['PostgreSQL is an OSS RDBMS', 'PostgreSQL has partial full-text search support']`. Given the query `contents &@ 'Groonga'`, the RLS check is used but does not effect the last result. It's because the above record doesn't match the above query's condition.

If we change the query condition with `contents &@ 'PostgreSQL'` that matches the above `nonexistent`'s record, we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.