### PR TITLE
test full-text-search/text-array/similar-v2: fix row level security tests

### DIFF
--- a/expected/full-text-search/text-array/similar-v2/row-level-security/bitmapscan.out
+++ b/expected/full-text-search/text-array/similar-v2/row-level-security/bitmapscan.out
@@ -12,11 +12,16 @@ INSERT INTO memos VALUES
          'PostgreSQL has partial full-text search support']);
 INSERT INTO memos VALUES
   (2,
+   'nonexistent',
+    ARRAY['Rroonga is an OSS Ruby binding for Groonga',
+          'Rroonga has full full-text search support based on Groonga to Ruby']);
+INSERT INTO memos VALUES
+  (3,
    'alice',
     ARRAY['Groonga is an OSS full-text search engine',
           'Groonga has full full-text search support']);
 INSERT INTO memos VALUES
-  (3,
+  (4,
    'alice',
    ARRAY['PGroonga is an OSS PostgreSQL extension',
          'PGroonga adds full full-text search support based on Groonga to PostgreSQL']);
@@ -47,8 +52,8 @@ SELECT id, contents
  WHERE contents &@* 'Mroonga: A MySQL plugin that uses Groonga';
  id |                                                         contents                                                         
 ----+--------------------------------------------------------------------------------------------------------------------------
-  2 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
-  3 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
+  3 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
+  4 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
 (2 rows)
 
 RESET SESSION AUTHORIZATION;

--- a/expected/full-text-search/text-array/similar-v2/row-level-security/indexscan.out
+++ b/expected/full-text-search/text-array/similar-v2/row-level-security/indexscan.out
@@ -12,11 +12,16 @@ INSERT INTO memos VALUES
          'PostgreSQL has partial full-text search support']);
 INSERT INTO memos VALUES
   (2,
+   'nonexistent',
+    ARRAY['Rroonga is an OSS Ruby binding for Groonga',
+          'Rroonga has full full-text search support based on Groonga to Ruby']);
+INSERT INTO memos VALUES
+  (3,
    'alice',
     ARRAY['Groonga is an OSS full-text search engine',
           'Groonga has full full-text search support']);
 INSERT INTO memos VALUES
-  (3,
+  (4,
    'alice',
    ARRAY['PGroonga is an OSS PostgreSQL extension',
          'PGroonga adds full full-text search support based on Groonga to PostgreSQL']);
@@ -45,8 +50,8 @@ SELECT id, contents
  WHERE contents &@* 'Mroonga: A MySQL plugin that uses Groonga';
  id |                                                         contents                                                         
 ----+--------------------------------------------------------------------------------------------------------------------------
-  2 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
-  3 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
+  3 | {"Groonga is an OSS full-text search engine","Groonga has full full-text search support"}
+  4 | {"PGroonga is an OSS PostgreSQL extension","PGroonga adds full full-text search support based on Groonga to PostgreSQL"}
 (2 rows)
 
 RESET SESSION AUTHORIZATION;

--- a/expected/full-text-search/text-array/similar-v2/row-level-security/seqscan.out
+++ b/expected/full-text-search/text-array/similar-v2/row-level-security/seqscan.out
@@ -12,11 +12,16 @@ INSERT INTO memos VALUES
          'PostgreSQL has partial full-text search support']);
 INSERT INTO memos VALUES
   (2,
+   'nonexistent',
+    ARRAY['Rroonga is an OSS Ruby binding for Groonga',
+          'Rroonga has full full-text search support based on Groonga to Ruby']);
+INSERT INTO memos VALUES
+  (3,
    'alice',
     ARRAY['Groonga is an OSS full-text search engine',
           'Groonga has full full-text search support']);
 INSERT INTO memos VALUES
-  (3,
+  (4,
    'alice',
    ARRAY['PGroonga is an OSS PostgreSQL extension',
          'PGroonga adds full full-text search support based on Groonga to PostgreSQL']);

--- a/sql/full-text-search/text-array/similar-v2/row-level-security/bitmapscan.sql
+++ b/sql/full-text-search/text-array/similar-v2/row-level-security/bitmapscan.sql
@@ -14,11 +14,16 @@ INSERT INTO memos VALUES
          'PostgreSQL has partial full-text search support']);
 INSERT INTO memos VALUES
   (2,
+   'nonexistent',
+    ARRAY['Rroonga is an OSS Ruby binding for Groonga',
+          'Rroonga has full full-text search support based on Groonga to Ruby']);
+INSERT INTO memos VALUES
+  (3,
    'alice',
     ARRAY['Groonga is an OSS full-text search engine',
           'Groonga has full full-text search support']);
 INSERT INTO memos VALUES
-  (3,
+  (4,
    'alice',
    ARRAY['PGroonga is an OSS PostgreSQL extension',
          'PGroonga adds full full-text search support based on Groonga to PostgreSQL']);

--- a/sql/full-text-search/text-array/similar-v2/row-level-security/indexscan.sql
+++ b/sql/full-text-search/text-array/similar-v2/row-level-security/indexscan.sql
@@ -14,11 +14,16 @@ INSERT INTO memos VALUES
          'PostgreSQL has partial full-text search support']);
 INSERT INTO memos VALUES
   (2,
+   'nonexistent',
+    ARRAY['Rroonga is an OSS Ruby binding for Groonga',
+          'Rroonga has full full-text search support based on Groonga to Ruby']);
+INSERT INTO memos VALUES
+  (3,
    'alice',
     ARRAY['Groonga is an OSS full-text search engine',
           'Groonga has full full-text search support']);
 INSERT INTO memos VALUES
-  (3,
+  (4,
    'alice',
    ARRAY['PGroonga is an OSS PostgreSQL extension',
          'PGroonga adds full full-text search support based on Groonga to PostgreSQL']);

--- a/sql/full-text-search/text-array/similar-v2/row-level-security/seqscan.sql
+++ b/sql/full-text-search/text-array/similar-v2/row-level-security/seqscan.sql
@@ -14,11 +14,16 @@ INSERT INTO memos VALUES
          'PostgreSQL has partial full-text search support']);
 INSERT INTO memos VALUES
   (2,
+   'nonexistent',
+    ARRAY['Rroonga is an OSS Ruby binding for Groonga',
+          'Rroonga has full full-text search support based on Groonga to Ruby']);
+INSERT INTO memos VALUES
+  (3,
    'alice',
     ARRAY['Groonga is an OSS full-text search engine',
           'Groonga has full full-text search support']);
 INSERT INTO memos VALUES
-  (3,
+  (4,
    'alice',
    ARRAY['PGroonga is an OSS PostgreSQL extension',
          'PGroonga adds full full-text search support based on Groonga to PostgreSQL']);


### PR DESCRIPTION
GitHub: GH-849

The first test row used `nonexistent` as `user_name` with content `'ARRAY['PostgreSQL is an OSS RDBMS', 'PostgreSQL has partial full-text search support']'`.

Given the query `'contents &@* 'Mroonga: A MySQL plugin that uses Groonga'`, the RLS check is used but does not effect the last result. It's because the first record's content doesn't match the above query's condition.

If we add an additional record with `ARRAY['Rroonga is an OSS Ruby binding for Groonga', 'Rroonga has full full-text search support based on Groonga to Ruby']` that matches the above query's condition, we can confirm that the row is correctly filtered by the RLS policy.

Note: Similar fixes will follow separately.