### PR TITLE
ci: remove workaround for dependency package install failure

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -91,15 +91,7 @@ pgroonga_package=$(basename $(ls ${packages_dir}/*-pgroonga-*.rpm | head -n1) | 
                      sed -e 's/-pgroonga-.*$/-pgroonga/g')
 postgresql_version=$(echo ${pgroonga_package} | grep -E -o '[0-9.]+')
 
-# TODO: This condition is workaround.
-# We can remove when the following issue resolved.
-# https://github.com/pgdg-packaging/pgdg-rpms/issues/105
-if [ "${os}" = "almalinux" ] && [ ${major_version} = "10" ]; then
-    ${DNF} --disablerepo=epel install -y postgresql${postgresql_version}-contrib
-else
-    ${DNF} install -y postgresql${postgresql_version}-contrib
-fi
-
+${DNF} install -y postgresql${postgresql_version}-contrib
 ${DNF} install -y ${packages_dir}/*.rpm
 
 echo "::endgroup::"


### PR DESCRIPTION
This reverts commit 99b928bdbbe52382b2ba60eac3fef897e73f6b72.

Because the following issue has already resolved.
https://github.com/pgdg-packaging/pgdg-rpms/issues/105

Packages build successful even if we removed this workaround as below.
https://github.com/komainu8/pgroonga/actions/runs/19124184093