### PR TITLE
custom-scan: Fix wrong snapshot usage

### DIFF
--- a/src/pgrn-custom-scan.c
+++ b/src/pgrn-custom-scan.c
@@ -781,8 +781,7 @@ PGrnMakeTupleTableSlot(CustomScanState *customScanState,
 	ListCell *cell;
 	ExecClearTuple(slot);
 	econtext->ecxt_scantuple = slot;
-	Snapshot snapshot = SnapshotAny;
-	snapshot = RegisterSnapshot(GetTransactionSnapshot());
+	Snapshot snapshot = RegisterSnapshot(GetTransactionSnapshot());
 	// We might add state->targetlist instead of ss.ps.plan->targetlist.
 	foreach (cell, customScanState->ss.ps.plan->targetlist)
 	{
@@ -857,8 +856,7 @@ PGrnMakeTupleTableSlot(CustomScanState *customScanState,
 		}
 		ttsIndex++;
 	}
-	if (snapshot != SnapshotAny)
-		UnregisterSnapshot(snapshot);
+	UnregisterSnapshot(snapshot);
 	return ExecStoreVirtualTuple(slot);
 }
 


### PR DESCRIPTION
Fix #896

We can't use `TGetTransactionSnapshot()` directly. We should use `PushActiveSnapshot()` or `RegisterSnapshot()`.

As  snapmgr.c write

```
 * Each of these functions returns a reference to a statically allocated
 * snapshot.  The statically allocated snapshot is subject to change on any
 * snapshot-related function call, and should not be used directly.  Instead,
 * call PushActiveSnapshot() or RegisterSnapshot() to create a longer-lived
 * copy and use that.
```