### PR TITLE
ci windows: use the latest version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,20 +22,20 @@ jobs:
       matrix:
         include:
           - postgresql-version-major: "13"
-            postgresql-version: "13.21-1"
+            postgresql-version: "13.23-1"
           - postgresql-version-major: "14"
-            postgresql-version: "14.18-1"
+            postgresql-version: "14.20-1"
           - postgresql-version-major: "15"
-            postgresql-version: "15.13-1"
+            postgresql-version: "15.15-1"
           - postgresql-version-major: "16"
-            postgresql-version: "16.9-1"
+            postgresql-version: "16.11-1"
           - postgresql-version-major: "17"
-            postgresql-version: "17.5-1"
+            postgresql-version: "17.7-1"
           - postgresql-version-major: "18"
-            postgresql-version: "18.0-1"
+            postgresql-version: "18.1-1"
           - groonga-main: "yes"
             postgresql-version-major: "18"
-            postgresql-version: "18.0-1"
+            postgresql-version: "18.1-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"


### PR DESCRIPTION
Because PostgreSQL 18.1, 17.7, 16.11, 15.15, 14.20, and 13.23 released at 2025-11-13.
See: https://www.postgresql.org/about/news/postgresql-181-177-1611-1515-1420-and-1323-released-3171/