### PR TITLE
semantic-search: add support for large (4KiB+) embedding

### DIFF
--- a/expected/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan.out
+++ b/expected/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan.out
@@ -1,0 +1,46 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///Qwen/Qwen3-Embedding-4B-GGUF',
+       n_gpu_layers = 0);
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+                                              QUERY PLAN                                              
+------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (pgroonga_score(tableoid, ctid)) DESC
+   ->  Bitmap Heap Scan on memos
+         Recheck Cond: (content &@* '("What is a MySQL alternative?",,,,,,)'::pgroonga_condition)
+         ->  Bitmap Index Scan on pgrn_index
+               Index Cond: (content &@* '("What is a MySQL alternative?",,,,,,)'::pgroonga_condition)
+(6 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+ id |                 content                  
+----+------------------------------------------
+  1 | PostgreSQL is a RDBMS.
+  2 | Groonga is fast full text search engine.
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan_1.out
+++ b/expected/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan_1.out
@@ -1,0 +1,5 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan_2.out
+++ b/expected/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan_2.out
@@ -1,0 +1,6 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+invalid command \getenv
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-condition-v2/large-embedding/indexscan.out
+++ b/expected/semantic-search/text/similar-condition-v2/large-embedding/indexscan.out
@@ -1,0 +1,44 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///Qwen/Qwen3-Embedding-4B-GGUF',
+       n_gpu_layers = 0);
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: (pgroonga_score(tableoid, ctid)) DESC
+   ->  Index Scan using pgrn_index on memos
+         Index Cond: (content &@* '("What is a MySQL alternative?",,,,,,)'::pgroonga_condition)
+(4 rows)
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+ id |                 content                  
+----+------------------------------------------
+  1 | PostgreSQL is a RDBMS.
+  2 | Groonga is fast full text search engine.
+(2 rows)
+
+DROP TABLE memos;

--- a/expected/semantic-search/text/similar-condition-v2/large-embedding/indexscan_1.out
+++ b/expected/semantic-search/text/similar-condition-v2/large-embedding/indexscan_1.out
@@ -1,0 +1,5 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/expected/semantic-search/text/similar-condition-v2/large-embedding/indexscan_2.out
+++ b/expected/semantic-search/text/similar-condition-v2/large-embedding/indexscan_2.out
@@ -1,0 +1,6 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+invalid command \getenv
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit

--- a/sql/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan.sql
+++ b/sql/semantic-search/text/similar-condition-v2/large-embedding/bitmapscan.sql
@@ -1,0 +1,37 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///Qwen/Qwen3-Embedding-4B-GGUF',
+       n_gpu_layers = 0);
+
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_bitmapscan = on;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+DROP TABLE memos;

--- a/sql/semantic-search/text/similar-condition-v2/large-embedding/indexscan.sql
+++ b/sql/semantic-search/text/similar-condition-v2/large-embedding/indexscan.sql
@@ -1,0 +1,37 @@
+-- Only test when `PGRN_LANGUAGE_MODEL_TEST` is set.
+\getenv language_model_test PGRN_LANGUAGE_MODEL_TEST
+SELECT NOT :{?language_model_test} AS omit \gset
+\if :omit
+  \quit
+\endif
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, 'PostgreSQL is a RDBMS.');
+INSERT INTO memos VALUES (2, 'Groonga is fast full text search engine.');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content pgroonga_text_semantic_search_ops_v2)
+ WITH (plugins = 'language_model/knn',
+       model = 'hf:///Qwen/Qwen3-Embedding-4B-GGUF',
+       n_gpu_layers = 0);
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+EXPLAIN (COSTS OFF)
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@* pgroonga_condition('What is a MySQL alternative?')
+ ORDER BY pgroonga_score(tableoid, ctid) DESC;
+
+DROP TABLE memos;

--- a/src/pgrn-constant.h
+++ b/src/pgrn-constant.h
@@ -39,6 +39,7 @@
 #define PGrnLexiconNameFormat PGrnLexiconNamePrefix "%u_%u"
 #define PGrnIndexColumnName "index"
 #define PGrnIndexColumnNameFormat PGrnLexiconNameFormat "." PGrnIndexColumnName
+#define PGrnCentroidColumnName "centroid"
 
 #define PGRN_EXPR_QUERY_PARSE_FLAGS                                            \
 	(GRN_EXPR_SYNTAX_QUERY | GRN_EXPR_ALLOW_LEADING_NOT |                      \

--- a/src/pgrn-options.h
+++ b/src/pgrn-options.h
@@ -20,9 +20,12 @@ typedef struct PGrnResolvedOptions
 	grn_obj *normalizers;
 	grn_obj *tokenFilters;
 	grn_obj *plugins;
+	grn_id lexiconKeyTypeID;
 	grn_table_flags lexiconType;
 	grn_column_flags indexFlags;
 	const char *modelName;
+	bool needCentroidColumn;
+	int32_t nGPULayers;
 } PGrnResolvedOptions;
 
 void PGrnInitializeOptions(void);


### PR DESCRIPTION
This require Groonga 15.2.1 or later.

If the specified language model uses 1025+ dimensions for embedding, we can't store it as a Groonga's table key. Because 1025+ dimensions embedding has 4KiB+ size and Groonga's table key's max size is 4KiB.

In the case, we store embedding to column not table key.

This also adds the `n_gpu_layers` option. We can use it for disabling GPU. If the specified language model is large, we may not be able to load it to (small) GPU. In the case, we can disable GPU. (It works but slow...)