### PR TITLE
language_model_vectorize: Add `IMMUTABLE` to `CREATE FUNCTION`

### DIFF
--- a/data/pgroonga--4.0.4--4.0.5.sql
+++ b/data/pgroonga--4.0.4--4.0.5.sql
@@ -4,6 +4,7 @@ CREATE OR REPLACE FUNCTION pgroonga_language_model_vectorize(model_name cstring,
 	RETURNS float4[]
 	AS 'MODULE_PATHNAME', 'pgroonga_language_model_vectorize'
 	LANGUAGE C
+	IMMUTABLE
 	STRICT
 	PARALLEL SAFE;
 

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -462,6 +462,7 @@ CREATE FUNCTION pgroonga_language_model_vectorize(model_name cstring, target tex
 	RETURNS float4[]
 	AS 'MODULE_PATHNAME', 'pgroonga_language_model_vectorize'
 	LANGUAGE C
+	IMMUTABLE
 	STRICT
 	PARALLEL SAFE;
 


### PR DESCRIPTION
GitHub fixes GH-906

In reality, pgroonga_language_model_vectorize() is not `IMMUTABLE`.
But, due to the nature of the function, some minor differences are acceptable, and for performance reasons, it is marked as `IMMUTABLE`.