### PR TITLE
language_model_vectorize: fix a bug that causes currentModelName to be invalid

### DIFF
--- a/src/pgrn-language-model-vectorize.c
+++ b/src/pgrn-language-model-vectorize.c
@@ -23,7 +23,7 @@ PGrnInitializeLanguageModelVectorize(void)
 {
 	loader = grn_language_model_loader_open(ctx);
 	GRN_FLOAT32_INIT(&vector, GRN_OBJ_VECTOR);
-	GRN_TEXT_INIT(&currentModelName, GRN_OBJ_DO_SHALLOW_COPY);
+	GRN_TEXT_INIT(&currentModelName, 0);
 }
 
 static void


### PR DESCRIPTION
The process may crash when executing the following query multiple times with pgvector.

```
SELECT pgroonga_language_model_vectorize(
  'hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF',
  column)::vector;
```

This is caused by `currentModelName` space being reused during the process, so we store it in `grn_obj` to persist it.