### PR TITLE
Add `flags` argument to `(index|table)_beginscan` for PostgreSQL 19 compatibility

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -3,6 +3,11 @@
 #include <postgres.h>
 
 #include <access/genam.h>
+#include <access/tableam.h>
+
+#ifndef SO_NONE
+#	define SO_NONE 0
+#endif
 
 #ifdef _WIN32
 #	define PRId64 "I64d"
@@ -114,7 +119,8 @@ pgrn_index_beginscan(Relation heapRelation,
 					 void *instrument,
 #endif
 					 int nKeys,
-					 int nOrderBys)
+					 int nOrderBys,
+					 uint32 flags)
 {
 
 	return index_beginscan(heapRelation,
@@ -124,7 +130,44 @@ pgrn_index_beginscan(Relation heapRelation,
 						   instrument,
 #endif
 						   nKeys,
-						   nOrderBys);
+						   nOrderBys
+#if PG_VERSION_NUM >= 190000
+						   ,
+						   flags
+#endif
+	);
+}
+
+static inline TableScanDesc
+pgrn_table_beginscan(Relation relation,
+					 Snapshot snapshot,
+					 int nKeys,
+					 ScanKeyData *scanKeys,
+					 uint32 flags)
+{
+	return table_beginscan(relation,
+						   snapshot,
+						   nKeys,
+						   scanKeys
+#if PG_VERSION_NUM >= 190000
+						   ,
+						   flags
+#endif
+	);
+}
+
+static inline TableScanDesc
+pgrn_table_beginscan_parallel(Relation relation,
+							  ParallelTableScanDesc pscan,
+							  uint32 flags)
+{
+	return table_beginscan_parallel(relation,
+									pscan
+#if PG_VERSION_NUM >= 190000
+									,
+									flags
+#endif
+	);
 }
 
 #if PG_VERSION_NUM >= 180000

--- a/src/pgrn-query-expand.c
+++ b/src/pgrn-query-expand.c
@@ -104,8 +104,8 @@ func_query_expander_postgresql(grn_ctx *ctx,
 					InvalidStrategy,
 					currentData.scanProcedure,
 					scanKeyDatum);
-		heapScan = table_beginscan(
-			currentData.table, currentData.snapshot, nKeys, scanKeys);
+		heapScan = pgrn_table_beginscan(
+			currentData.table, currentData.snapshot, nKeys, scanKeys, SO_NONE);
 	}
 
 	while (true)
@@ -564,7 +564,8 @@ pgroonga_query_expand(PG_FUNCTION_ARGS)
 												currentData.snapshot,
 												NULL,
 												nKeys,
-												nOrderBys);
+												nOrderBys,
+												SO_NONE);
 		currentData.slot = table_slot_create(currentData.table, NULL);
 	}
 	else

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -7932,7 +7932,8 @@ pgroonga_build_copy_source_worker(PGrnParallelBuildLocalData *localData,
 	createData.indexInfo = BuildIndexInfo(localData->index);
 	createData.indexInfo->ii_Concurrent = sharedData->isConcurrent;
 	progress = (ParallelWorkerNumber == -1);
-	scan = table_beginscan_parallel(localData->heap, localData->pscan);
+	scan = pgrn_table_beginscan_parallel(
+		localData->heap, localData->pscan, SO_NONE);
 	pgroonga_build_copy_source_execute(&createData, bs, progress, scan);
 
 	SpinLockAcquire(&(sharedData->mutex));


### PR DESCRIPTION
Related commit:
https://github.com/postgres/postgres/commit/dcd8cc1c852cac4e65d336a79afb6b9eb9700ae1