### PR TITLE
ci windows: Build with --buildtype=release

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -192,6 +192,7 @@ jobs:
         run: |
           call "%VC_PREFIX%\Auxiliary\Build\vcvars64.bat"
           meson setup ^
+            --buildtype=release ^
             --cmake-prefix-path="%ARCHIVE_DIR%" ^
             --prefix="%ARCHIVE_DIR%" ^
             -Dinstall_to_postgresql=false ^


### PR DESCRIPTION
GitHub: Fix GH-954

Meson's default buildtype is `debug`, so specify `release` explicitly.

Reported by r-setoyama. Thanks!!!