### PR TITLE
ci windows: use the latest version for PostgreSQL

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,18 +24,18 @@ jobs:
       matrix:
         include:
           - postgresql-version-major: "14"
-            postgresql-version: "14.22-1"
+            postgresql-version: "14.23-1"
           - postgresql-version-major: "15"
-            postgresql-version: "15.17-1"
+            postgresql-version: "15.18-1"
           - postgresql-version-major: "16"
-            postgresql-version: "16.13-1"
+            postgresql-version: "16.14-1"
           - postgresql-version-major: "17"
-            postgresql-version: "17.9-1"
+            postgresql-version: "17.10-1"
           - postgresql-version-major: "18"
-            postgresql-version: "18.3-1"
+            postgresql-version: "18.4-1"
           - groonga-main: "yes"
             postgresql-version-major: "18"
-            postgresql-version: "18.3-1"
+            postgresql-version: "18.4-1"
     env:
       PGROONGA_BENCHMARK_GEMFILE: ${{ github.workspace }}\pgroonga-benchmark\Gemfile
       PGROONGA_TEST_DATA: "test-data"


### PR DESCRIPTION
PostgreSQL 18.4, 17.10, 16.14, 15.18, and 14.23 Released at 2026-05-14.
Ref: https://www.postgresql.org/about/news/postgresql-184-1710-1614-1518-and-1423-released-3297/