### PR TITLE
Follow PostgreSQL 19 pg_noreturn/pg_attribute_noreturn() usage

### DIFF
--- a/src/pgrn-compatible.h
+++ b/src/pgrn-compatible.h
@@ -90,9 +90,7 @@ typedef Oid PGrnRelFileNumber;
 		((parallelScan)->ps_offset)
 #endif
 
-#if PG_VERSION_NUM >= 180000
-#	define pg_attribute_noreturn()
-#else
+#if PG_VERSION_NUM < 180000
 #	define pg_noreturn
 #endif
 

--- a/src/pgroonga-crash-safer.c
+++ b/src/pgroonga-crash-safer.c
@@ -44,14 +44,12 @@ static grn_ctx *ctx = NULL;
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
-extern PGDLLEXPORT pg_noreturn void
-pgroonga_crash_safer_reset_position_one(Datum datum) pg_attribute_noreturn();
-extern PGDLLEXPORT pg_noreturn void
-pgroonga_crash_safer_reindex_one(Datum datum) pg_attribute_noreturn();
-extern PGDLLEXPORT pg_noreturn void pgroonga_crash_safer_flush_one(Datum datum)
-	pg_attribute_noreturn();
-extern PGDLLEXPORT pg_noreturn void pgroonga_crash_safer_main(Datum datum)
-	pg_attribute_noreturn();
+pg_noreturn extern PGDLLEXPORT void
+pgroonga_crash_safer_reset_position_one(Datum datum);
+pg_noreturn extern PGDLLEXPORT void
+pgroonga_crash_safer_reindex_one(Datum datum);
+pg_noreturn extern PGDLLEXPORT void pgroonga_crash_safer_flush_one(Datum datum);
+pg_noreturn extern PGDLLEXPORT void pgroonga_crash_safer_main(Datum datum);
 
 static volatile sig_atomic_t PGroongaCrashSaferGotSIGTERM = false;
 static volatile sig_atomic_t PGroongaCrashSaferGotSIGHUP = false;

--- a/src/pgroonga-standby-maintainer.c
+++ b/src/pgroonga-standby-maintainer.c
@@ -20,12 +20,12 @@
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
-extern PGDLLEXPORT pg_noreturn void
-pgroonga_standby_maintainer_apply_wal(Datum datum) pg_attribute_noreturn();
-extern PGDLLEXPORT pg_noreturn void
-pgroonga_standby_maintainer_maintain(Datum datum) pg_attribute_noreturn();
-extern PGDLLEXPORT pg_noreturn void
-pgroonga_standby_maintainer_main(Datum datum) pg_attribute_noreturn();
+pg_noreturn extern PGDLLEXPORT void
+pgroonga_standby_maintainer_apply_wal(Datum datum);
+pg_noreturn extern PGDLLEXPORT void
+pgroonga_standby_maintainer_maintain(Datum datum);
+pg_noreturn extern PGDLLEXPORT void
+pgroonga_standby_maintainer_main(Datum datum);
 
 #define TAG "pgroonga: standby-maintainer"
 

--- a/src/pgroonga-wal-applier.c
+++ b/src/pgroonga-wal-applier.c
@@ -18,10 +18,8 @@
 PG_MODULE_MAGIC;
 
 extern PGDLLEXPORT void _PG_init(void);
-extern PGDLLEXPORT pg_noreturn void pgroonga_wal_applier_apply(Datum datum)
-	pg_attribute_noreturn();
-extern PGDLLEXPORT pg_noreturn void pgroonga_wal_applier_main(Datum datum)
-	pg_attribute_noreturn();
+pg_noreturn extern PGDLLEXPORT void pgroonga_wal_applier_apply(Datum datum);
+pg_noreturn extern PGDLLEXPORT void pgroonga_wal_applier_main(Datum datum);
 
 #define TAG "pgroonga: wal-applier"
 


### PR DESCRIPTION
`pg_attribute_noreturn()` was removed by
https://github.com/postgres/postgres/commit/3691edfab97187789b8a1cbb9dce4acf0ecd8f5a .

`pg_noreturn` uses C23 attribute by
https://github.com/postgres/postgres/commit/76f4b92bac87fa54bd6dd8bd53e59f93127ec2ef .
So we need to use `pg_noreturn` before `extern`.