### PR TITLE
Add match explanation function

### DIFF
--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -358,6 +358,14 @@ CREATE FUNCTION pgroonga_tokenize(target text, VARIADIC options text[])
 	STRICT
 	PARALLEL SAFE;
 
+CREATE FUNCTION pgroonga_explain_match(indexName cstring, query text)
+	RETURNS jsonb
+	AS 'MODULE_PATHNAME', 'pgroonga_explain_match'
+	LANGUAGE C
+	STABLE
+	STRICT
+	PARALLEL SAFE;
+
 CREATE FUNCTION pgroonga_vacuum()
 	RETURNS bool
 	AS 'MODULE_PATHNAME', 'pgroonga_vacuum'

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -366,6 +366,15 @@ CREATE FUNCTION pgroonga_explain_match(indexName cstring, query text)
 	STRICT
 	PARALLEL SAFE;
 
+CREATE FUNCTION pgroonga_normalizer_table_variants(indexName cstring,
+						   normalized text)
+	RETURNS text[]
+	AS 'MODULE_PATHNAME', 'pgroonga_normalizer_table_variants'
+	LANGUAGE C
+	STABLE
+	STRICT
+	PARALLEL SAFE;
+
 CREATE FUNCTION pgroonga_vacuum()
 	RETURNS bool
 	AS 'MODULE_PATHNAME', 'pgroonga_vacuum'

--- a/expected/full-text-search/text/options/normalizer/parameters.out
+++ b/expected/full-text-search/text/options/normalizer/parameters.out
@@ -6,30 +6,35 @@ CREATE INDEX pgrn_index ON memos
  USING pgroonga (tags)
   WITH (normalizer = 'NormalizerNFKC100("unify_kana", true)');
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グルンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
-  jsonb_pretty  
-----------------
- [             +
-     [         +
-         "が"  +
-     ],        +
-     [         +
-         "ぐる"+
-     ],        +
-     [         +
-         "るん"+
-     ],        +
-     [         +
-         "んが"+
-     ]         +
+             jsonb_pretty             
+--------------------------------------
+ [                                   +
+     {                               +
+         "value": "ぐる",            +
+         "position": 0,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "るん",            +
+         "position": 1,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "んが",            +
+         "position": 2,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     }                               +
  ]
 (1 row)
 

--- a/expected/full-text-search/text/options/normalizers-mapping/variable/table.out
+++ b/expected/full-text-search/text/options/normalizers-mapping/variable/table.out
@@ -17,30 +17,35 @@ CREATE INDEX pgrn_index ON memos
           "content": "NormalizerNFKC130(\"unify_kana\", true), NormalizerTable(\"normalized\", \"${table:public.pgrn_normalizations_index}.normalized\", \"target\", \"target\")"
        }');
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グルンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
-  jsonb_pretty  
-----------------
- [             +
-     [         +
-         "か"  +
-     ],        +
-     [         +
-         "くる"+
-     ],        +
-     [         +
-         "るん"+
-     ],        +
-     [         +
-         "んか"+
-     ]         +
+             jsonb_pretty             
+--------------------------------------
+ [                                   +
+     {                               +
+         "value": "くる",            +
+         "position": 0,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "るん",            +
+         "position": 1,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "んか",            +
+         "position": 2,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     }                               +
  ]
 (1 row)
 

--- a/expected/full-text-search/text/options/normalizers/parameters.out
+++ b/expected/full-text-search/text/options/normalizers/parameters.out
@@ -7,33 +7,35 @@ CREATE INDEX pgrn_index ON memos
   WITH (normalizers = 'NormalizerNFKC130("unify_kana", true),
                        NormalizerNFKC130("unify_middle_dot", true)');
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グル∙ンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
-  jsonb_pretty  
-----------------
- [             +
-     [         +
-         "·"   +
-     ],        +
-     [         +
-         "が"  +
-     ],        +
-     [         +
-         "ぐる"+
-     ],        +
-     [         +
-         "る"  +
-     ],        +
-     [         +
-         "んが"+
-     ]         +
+             jsonb_pretty             
+--------------------------------------
+ [                                   +
+     {                               +
+         "value": "ぐる",            +
+         "position": 0,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "·",               +
+         "position": 2,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "んが",            +
+         "position": 3,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     }                               +
  ]
 (1 row)
 

--- a/expected/full-text-search/text/options/normalizers/variable/table.out
+++ b/expected/full-text-search/text/options/normalizers/variable/table.out
@@ -19,30 +19,35 @@ CREATE INDEX pgrn_index ON memos
                            "${table:public.pgrn_normalizations_index}.normalized",
                            "target", "target")');
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グルンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
-  jsonb_pretty  
-----------------
- [             +
-     [         +
-         "か"  +
-     ],        +
-     [         +
-         "くる"+
-     ],        +
-     [         +
-         "るん"+
-     ],        +
-     [         +
-         "んか"+
-     ]         +
+             jsonb_pretty             
+--------------------------------------
+ [                                   +
+     {                               +
+         "value": "くる",            +
+         "position": 0,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "るん",            +
+         "position": 1,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "んか",            +
+         "position": 2,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     }                               +
  ]
 (1 row)
 

--- a/expected/full-text-search/text/options/tokenizer/parameters.out
+++ b/expected/full-text-search/text/options/tokenizer/parameters.out
@@ -7,66 +7,101 @@ CREATE INDEX pgrn_index ON memos
   WITH (tokenizer = 'TokenNgram("n", 3)',
         normalizer = '');
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'PGroonga is fast',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
- jsonb_pretty  
----------------
- [            +
-     [        +
-         " fa"+
-     ],       +
-     [        +
-         " is"+
-     ],       +
-     [        +
-         "Gro"+
-     ],       +
-     [        +
-         "PGr"+
-     ],       +
-     [        +
-         "a i"+
-     ],       +
-     [        +
-         "ast"+
-     ],       +
-     [        +
-         "fas"+
-     ],       +
-     [        +
-         "ga "+
-     ],       +
-     [        +
-         "is "+
-     ],       +
-     [        +
-         "nga"+
-     ],       +
-     [        +
-         "ong"+
-     ],       +
-     [        +
-         "oon"+
-     ],       +
-     [        +
-         "roo"+
-     ],       +
-     [        +
-         "s f"+
-     ],       +
-     [        +
-         "st" +
-     ],       +
-     [        +
-         "t"  +
-     ]        +
+             jsonb_pretty             
+--------------------------------------
+ [                                   +
+     {                               +
+         "value": "PGr",             +
+         "position": 0,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "Gro",             +
+         "position": 1,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "roo",             +
+         "position": 2,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "oon",             +
+         "position": 3,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "ong",             +
+         "position": 4,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "nga",             +
+         "position": 5,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "ga ",             +
+         "position": 6,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "a i",             +
+         "position": 7,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": " is",             +
+         "position": 8,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "is ",             +
+         "position": 9,              +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "s f",             +
+         "position": 10,             +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": " fa",             +
+         "position": 11,             +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "fas",             +
+         "position": 12,             +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     },                              +
+     {                               +
+         "value": "ast",             +
+         "position": 13,             +
+         "force_prefix": false,      +
+         "force_prefix_search": false+
+     }                               +
  ]
 (1 row)
 

--- a/expected/function/explain-match/normalizer-table.out
+++ b/expected/function/explain-match/normalizer-table.out
@@ -1,0 +1,124 @@
+CREATE TABLE normalizations (
+  target text,
+  normalized text
+);
+CREATE INDEX pgrn_normalizations_index ON normalizations
+ USING pgroonga (target pgroonga_text_term_search_ops_v2,
+                 normalized);
+INSERT INTO normalizations VALUES ('齋', '斉');
+INSERT INTO normalizations VALUES ('斎', '斉');
+INSERT INTO normalizations VALUES ('渡邉', '渡辺');
+INSERT INTO normalizations VALUES ('渡邊', '渡辺');
+INSERT INTO normalizations VALUES ('渡部', '渡辺');
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+INSERT INTO memos VALUES (1, '斉藤');
+INSERT INTO memos VALUES (2, '渡辺');
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content)
+  WITH (normalizers =
+          'NormalizerTable("normalized",
+                           "${table:public.pgrn_normalizations_index}.normalized",
+                           "target", "target")',
+        tokenizer = 'TokenNgram("report_source_location", true)');
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+\pset format unaligned
+SELECT id, content
+  FROM memos
+ WHERE content &@ '齋藤'
+ ORDER BY id;
+id|content
+1|斉藤
+(1 row)
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '齋藤')->'tokens'
+  ) AS token;
+source|value|position|in_lexicon
+齋藤|斉藤|0|true
+藤|藤|1|true
+(2 rows)
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgrn_index', '齋藤')->'matched_terms'
+);
+jsonb_array_elements_text
+斉藤
+藤
+(2 rows)
+SELECT id, content
+  FROM memos
+ WHERE content &@ '渡邉'
+ ORDER BY id;
+id|content
+2|渡辺
+(1 row)
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '渡邉')->'tokens'
+  ) AS token;
+source|value|position|in_lexicon
+渡邉|渡辺|0|true
+邉|辺|1|true
+(2 rows)
+SELECT id, content
+  FROM memos
+ WHERE content &@ '渡邊'
+ ORDER BY id;
+id|content
+2|渡辺
+(1 row)
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '渡邊')->'tokens'
+  ) AS token;
+source|value|position|in_lexicon
+渡邊|渡辺|0|true
+邊|辺|1|true
+(2 rows)
+SELECT id, content
+  FROM memos
+ WHERE content &@ '渡部'
+ ORDER BY id;
+id|content
+2|渡辺
+(1 row)
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '渡部')->'tokens'
+  ) AS token;
+source|value|position|in_lexicon
+渡部|渡辺|0|true
+部|辺|1|true
+(2 rows)
+SELECT unnest(pgroonga_normalizer_table_variants('pgrn_index', '斉藤'));
+unnest
+齋藤
+斎藤
+斉藤
+(3 rows)
+SELECT unnest(pgroonga_normalizer_table_variants('pgrn_index', '渡辺'));
+unnest
+渡邉
+渡邊
+渡部
+渡辺
+(4 rows)
+\pset format aligned
+DROP TABLE normalizations;
+DROP TABLE memos;

--- a/expected/function/explain-match/romaji.out
+++ b/expected/function/explain-match/romaji.out
@@ -1,0 +1,112 @@
+CREATE TABLE memos (
+  id integer,
+  title text,
+  content text
+);
+INSERT INTO memos VALUES
+  (1,
+   'PostgreSQLはリレーショナル・データベース管理システムです。',
+   'すごいでしょう');
+INSERT INTO memos VALUES
+  (2,
+   'Groongaは日本語対応の高速な全文検索エンジンです。',
+   'スゴイデショウ');
+INSERT INTO memos VALUES
+  (3,
+   'PGroongaはインデックスとしてGroongaを使うためのPostgreSQLの拡張機能です。',
+   'ハバナイスデー');
+INSERT INTO memos VALUES
+  (4,
+   'groongaコマンドがあります。',
+   '今日はコンバンワこんにちわ');
+CREATE INDEX pgroonga_title_search_index ON memos USING pgroonga (title)
+  WITH (
+    normalizers = 'NormalizerNFKC150(
+                     "unify_to_romaji", true,
+                     "unify_hyphen_and_prolonged_sound_mark", true
+                   )',
+    tokenizer='TokenNgram(
+                 "unify_alphabet", false,
+                 "unify_symbol", false,
+                 "unify_digit", false,
+                 "report_source_location", true
+               )'
+  );
+CREATE INDEX pgroonga_content_search_index ON memos USING pgroonga (content)
+  WITH (
+    normalizers = 'NormalizerNFKC150(
+                     "unify_to_romaji", true,
+                     "unify_hyphen_and_prolonged_sound_mark", true
+                   )',
+    tokenizer='TokenNgram(
+                 "unify_alphabet", false,
+                 "unify_symbol", false,
+                 "unify_digit", false,
+                 "report_source_location", true
+               )'
+  );
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+\pset format unaligned
+SELECT id, content
+  FROM memos
+ WHERE content &@ 'すごい'
+ ORDER BY id;
+id|content
+1|すごいでしょう
+2|スゴイデショウ
+(2 rows)
+SELECT token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgroonga_content_search_index', 'すごい')->'tokens'
+  ) AS token;
+value|position|in_lexicon
+su|0|true
+ug|1|true
+go|2|true
+oi|3|true
+i|4|false
+(5 rows)
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgroonga_content_search_index', 'すごい')->'matched_terms'
+);
+jsonb_array_elements_text
+su
+ug
+go
+oi
+(4 rows)
+SELECT id, content
+  FROM memos
+ WHERE title &@~ 'デス'
+ ORDER BY id;
+id|content
+1|すごいでしょう
+2|スゴイデショウ
+3|ハバナイスデー
+(3 rows)
+SELECT token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgroonga_title_search_index', 'デス')->'tokens'
+  ) AS token;
+value|position|in_lexicon
+de|0|true
+es|1|true
+su|2|true
+u|3|false
+(4 rows)
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgroonga_title_search_index', 'デス')->'matched_terms'
+);
+jsonb_array_elements_text
+de
+es
+su
+(3 rows)
+\pset format aligned
+DROP TABLE memos;

--- a/expected/function/explain-match/token.out
+++ b/expected/function/explain-match/token.out
@@ -1,0 +1,25 @@
+CREATE TABLE memos (
+  content text
+);
+INSERT INTO memos VALUES ('PGroonga');
+CREATE INDEX pgrn_index ON memos
+  USING pgroonga (content)
+  WITH (tokenizer = 'TokenDelimit');
+\pset format unaligned
+SELECT token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', 'pgroonga')->'tokens'
+  ) AS token;
+value|position|in_lexicon
+pgroonga|0|true
+(1 row)
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgrn_index', 'pgroonga')->'matched_terms'
+);
+jsonb_array_elements_text
+pgroonga
+(1 row)
+\pset format aligned
+DROP TABLE memos;

--- a/meson.build
+++ b/meson.build
@@ -186,6 +186,7 @@ pgroonga_sources = files(
   'src/pgrn-match-positions-byte.c',
   'src/pgrn-match-positions-character.c',
   'src/pgrn-normalize.c',
+  'src/pgrn-normalizer-table-variants.c',
   'src/pgrn-options.c',
   'src/pgrn-pg.c',
   'src/pgrn-query-escape.c',

--- a/meson.build
+++ b/meson.build
@@ -170,6 +170,7 @@ pgroonga_sources = files(
   'src/pgrn-ctid.c',
   'src/pgrn-custom-scan.c',
   'src/pgrn-escape.c',
+  'src/pgrn-explain-match.c',
   'src/pgrn-flush.c',
   'src/pgrn-condition.c',
   'src/pgrn-global.c',

--- a/sql/full-text-search/text/options/normalizer/parameters.sql
+++ b/sql/full-text-search/text/options/normalizer/parameters.sql
@@ -9,14 +9,13 @@ CREATE INDEX pgrn_index ON memos
   WITH (normalizer = 'NormalizerNFKC100("unify_kana", true)');
 
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グルンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
 
 DROP TABLE memos;

--- a/sql/full-text-search/text/options/normalizers-mapping/variable/table.sql
+++ b/sql/full-text-search/text/options/normalizers-mapping/variable/table.sql
@@ -23,14 +23,13 @@ CREATE INDEX pgrn_index ON memos
        }');
 
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グルンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
 
 DROP TABLE normalizations;

--- a/sql/full-text-search/text/options/normalizers/parameters.sql
+++ b/sql/full-text-search/text/options/normalizers/parameters.sql
@@ -10,14 +10,13 @@ CREATE INDEX pgrn_index ON memos
                        NormalizerNFKC130("unify_middle_dot", true)');
 
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グル∙ンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
 
 DROP TABLE memos;

--- a/sql/full-text-search/text/options/normalizers/variable/table.sql
+++ b/sql/full-text-search/text/options/normalizers/variable/table.sql
@@ -25,14 +25,13 @@ CREATE INDEX pgrn_index ON memos
                            "target", "target")');
 
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'グルンガ',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
 
 DROP TABLE normalizations;

--- a/sql/full-text-search/text/options/tokenizer/parameters.sql
+++ b/sql/full-text-search/text/options/tokenizer/parameters.sql
@@ -10,14 +10,13 @@ CREATE INDEX pgrn_index ON memos
         normalizer = '');
 
 SELECT jsonb_pretty(
-  pgroonga_command('select',
+  pgroonga_command('table_tokenize',
                    ARRAY[
                      'table', 'Lexicon' || 'pgrn_index'::regclass::oid || '_0',
-                     'limit', '-1',
-                     'sort_keys', '_key',
-                     'output_columns', '_key',
+                     'string', 'PGroonga is fast',
+                     'mode', 'GET',
                      'command_version', '3'
-                   ])::jsonb->'body'->'records'
+                   ])::jsonb->'body'
 );
 
 DROP TABLE memos;

--- a/sql/function/explain-match/normalizer-table.sql
+++ b/sql/function/explain-match/normalizer-table.sql
@@ -1,0 +1,99 @@
+CREATE TABLE normalizations (
+  target text,
+  normalized text
+);
+
+CREATE INDEX pgrn_normalizations_index ON normalizations
+ USING pgroonga (target pgroonga_text_term_search_ops_v2,
+                 normalized);
+
+INSERT INTO normalizations VALUES ('齋', '斉');
+INSERT INTO normalizations VALUES ('斎', '斉');
+INSERT INTO normalizations VALUES ('渡邉', '渡辺');
+INSERT INTO normalizations VALUES ('渡邊', '渡辺');
+INSERT INTO normalizations VALUES ('渡部', '渡辺');
+
+CREATE TABLE memos (
+  id integer,
+  content text
+);
+
+INSERT INTO memos VALUES (1, '斉藤');
+INSERT INTO memos VALUES (2, '渡辺');
+
+CREATE INDEX pgrn_index ON memos
+ USING pgroonga (content)
+  WITH (normalizers =
+          'NormalizerTable("normalized",
+                           "${table:public.pgrn_normalizations_index}.normalized",
+                           "target", "target")',
+        tokenizer = 'TokenNgram("report_source_location", true)');
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+\pset format unaligned
+SELECT id, content
+  FROM memos
+ WHERE content &@ '齋藤'
+ ORDER BY id;
+
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '齋藤')->'tokens'
+  ) AS token;
+
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgrn_index', '齋藤')->'matched_terms'
+);
+
+SELECT id, content
+  FROM memos
+ WHERE content &@ '渡邉'
+ ORDER BY id;
+
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '渡邉')->'tokens'
+  ) AS token;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@ '渡邊'
+ ORDER BY id;
+
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '渡邊')->'tokens'
+  ) AS token;
+
+SELECT id, content
+  FROM memos
+ WHERE content &@ '渡部'
+ ORDER BY id;
+
+SELECT token->>'source' AS source,
+       token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', '渡部')->'tokens'
+  ) AS token;
+
+SELECT unnest(pgroonga_normalizer_table_variants('pgrn_index', '斉藤'));
+
+SELECT unnest(pgroonga_normalizer_table_variants('pgrn_index', '渡辺'));
+\pset format aligned
+
+DROP TABLE normalizations;
+DROP TABLE memos;

--- a/sql/function/explain-match/romaji.sql
+++ b/sql/function/explain-match/romaji.sql
@@ -1,0 +1,90 @@
+CREATE TABLE memos (
+  id integer,
+  title text,
+  content text
+);
+
+INSERT INTO memos VALUES
+  (1,
+   'PostgreSQLはリレーショナル・データベース管理システムです。',
+   'すごいでしょう');
+INSERT INTO memos VALUES
+  (2,
+   'Groongaは日本語対応の高速な全文検索エンジンです。',
+   'スゴイデショウ');
+INSERT INTO memos VALUES
+  (3,
+   'PGroongaはインデックスとしてGroongaを使うためのPostgreSQLの拡張機能です。',
+   'ハバナイスデー');
+INSERT INTO memos VALUES
+  (4,
+   'groongaコマンドがあります。',
+   '今日はコンバンワこんにちわ');
+
+CREATE INDEX pgroonga_title_search_index ON memos USING pgroonga (title)
+  WITH (
+    normalizers = 'NormalizerNFKC150(
+                     "unify_to_romaji", true,
+                     "unify_hyphen_and_prolonged_sound_mark", true
+                   )',
+    tokenizer='TokenNgram(
+                 "unify_alphabet", false,
+                 "unify_symbol", false,
+                 "unify_digit", false,
+                 "report_source_location", true
+               )'
+  );
+
+CREATE INDEX pgroonga_content_search_index ON memos USING pgroonga (content)
+  WITH (
+    normalizers = 'NormalizerNFKC150(
+                     "unify_to_romaji", true,
+                     "unify_hyphen_and_prolonged_sound_mark", true
+                   )',
+    tokenizer='TokenNgram(
+                 "unify_alphabet", false,
+                 "unify_symbol", false,
+                 "unify_digit", false,
+                 "report_source_location", true
+               )'
+  );
+
+SET enable_seqscan = off;
+SET enable_indexscan = on;
+SET enable_bitmapscan = off;
+
+\pset format unaligned
+SELECT id, content
+  FROM memos
+ WHERE content &@ 'すごい'
+ ORDER BY id;
+
+SELECT token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgroonga_content_search_index', 'すごい')->'tokens'
+  ) AS token;
+
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgroonga_content_search_index', 'すごい')->'matched_terms'
+);
+
+SELECT id, content
+  FROM memos
+ WHERE title &@~ 'デス'
+ ORDER BY id;
+
+SELECT token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgroonga_title_search_index', 'デス')->'tokens'
+  ) AS token;
+
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgroonga_title_search_index', 'デス')->'matched_terms'
+);
+\pset format aligned
+
+DROP TABLE memos;

--- a/sql/function/explain-match/token.sql
+++ b/sql/function/explain-match/token.sql
@@ -1,0 +1,24 @@
+CREATE TABLE memos (
+  content text
+);
+
+INSERT INTO memos VALUES ('PGroonga');
+
+CREATE INDEX pgrn_index ON memos
+  USING pgroonga (content)
+  WITH (tokenizer = 'TokenDelimit');
+
+\pset format unaligned
+SELECT token->>'value' AS value,
+       token->>'position' AS position,
+       token->>'in_lexicon' AS in_lexicon
+  FROM jsonb_array_elements(
+    pgroonga_explain_match('pgrn_index', 'pgroonga')->'tokens'
+  ) AS token;
+
+SELECT jsonb_array_elements_text(
+  pgroonga_explain_match('pgrn_index', 'pgroonga')->'matched_terms'
+);
+\pset format aligned
+
+DROP TABLE memos;

--- a/src/pgrn-explain-match.c
+++ b/src/pgrn-explain-match.c
@@ -1,0 +1,240 @@
+#include "pgroonga.h"
+
+#include "pgrn-groonga.h"
+#include "pgrn-jsonb.h"
+#include "pgrn-pg.h"
+
+#include <utils/builtins.h>
+
+#include <string.h>
+
+static grn_obj json;
+
+PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_explain_match);
+
+void
+PGrnInitializeExplainMatch(void)
+{
+	GRN_TEXT_INIT(&json, 0);
+}
+
+void
+PGrnFinalizeExplainMatch(void)
+{
+	GRN_OBJ_FIN(ctx, &json);
+}
+
+static int
+PGrnExplainMatchResolveLexiconIndex(Relation index,
+									const char *attributeName,
+									size_t attributeNameSize)
+{
+	int i;
+
+	if (attributeNameSize > 0)
+	{
+		i = PGrnPGResolveAttributeIndex(index, attributeName, attributeNameSize);
+		if (i != -1)
+			return i;
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("pgroonga: [explain-match] "
+						"index doesn't have the specified attribute: <%s.%.*s>",
+						RelationGetRelationName(index),
+						(int) attributeNameSize,
+						attributeName)));
+	}
+
+	for (i = 0; i < index->rd_att->natts; i++)
+	{
+		grn_obj *lexicon;
+		bool isTextLexicon;
+
+		lexicon = PGrnLookupLexicon(index, i, ERROR);
+		isTextLexicon = grn_type_id_is_text_family(ctx, lexicon->header.domain);
+		grn_obj_unref(ctx, lexicon);
+		if (isTextLexicon)
+			return i;
+	}
+
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("pgroonga: [explain-match] "
+					"index doesn't have a lexicon for text: <%s>",
+					RelationGetRelationName(index))));
+	return -1;
+}
+
+static void
+PGrnExplainMatchOutputText(grn_content_type type,
+						   const char *name,
+						   const char *value,
+						   size_t valueSize)
+{
+	grn_output_cstr(ctx, &json, type, name);
+	grn_output_str(ctx, &json, type, value, valueSize);
+}
+
+static void
+PGrnExplainMatchOutputLexiconName(grn_content_type type, grn_obj *lexicon)
+{
+	char lexiconName[GRN_TABLE_MAX_KEY_SIZE];
+	int lexiconNameSize;
+
+	lexiconNameSize =
+		grn_obj_name(ctx, lexicon, lexiconName, sizeof(lexiconName));
+	PGrnExplainMatchOutputText(
+		type, "lexicon_name", lexiconName, lexiconNameSize);
+}
+
+/**
+ * pgroonga_explain_match(indexName cstring, query text) : jsonb
+ */
+Datum
+pgroonga_explain_match(PG_FUNCTION_ARGS)
+{
+	char *fullIndexName = PG_GETARG_CSTRING(0);
+	text *query = PG_GETARG_TEXT_PP(1);
+	const char *indexName;
+	size_t indexNameSize;
+	const char *attributeName;
+	size_t attributeNameSize;
+	char *nulTerminatedIndexName;
+	Relation index;
+	int lexiconIndex;
+	grn_obj *lexicon;
+	grn_obj *temporaryLexicon;
+	grn_token_cursor *tokenCursor;
+	grn_obj matchedTerms;
+	grn_content_type type = GRN_CONTENT_JSON;
+	Jsonb *jsonb;
+
+	PGrnPGFullIndexNameSplit(fullIndexName,
+							 strlen(fullIndexName),
+							 &indexName,
+							 &indexNameSize,
+							 &attributeName,
+							 &attributeNameSize);
+	nulTerminatedIndexName = pnstrdup(indexName, indexNameSize);
+	index = PGrnPGResolveIndexName(nulTerminatedIndexName);
+
+	lexiconIndex = PGrnExplainMatchResolveLexiconIndex(index,
+													   attributeName,
+													   attributeNameSize);
+	lexicon = PGrnLookupLexicon(index, lexiconIndex, ERROR);
+	temporaryLexicon = PGrnCreateSimilarTemporaryLexicon(index,
+														 attributeName,
+														 attributeNameSize,
+														 "[explain-match]");
+
+	GRN_BULK_REWIND(&json);
+	grn_output_map_open(ctx, &json, type, "explain_match", 6);
+	PGrnExplainMatchOutputText(
+		type, "query", VARDATA_ANY(query), VARSIZE_ANY_EXHDR(query));
+	PGrnExplainMatchOutputText(type, "index_name", indexName, indexNameSize);
+	if (attributeNameSize > 0)
+	{
+		PGrnExplainMatchOutputText(
+			type, "attribute_name", attributeName, attributeNameSize);
+	}
+	else
+	{
+		grn_output_cstr(ctx, &json, type, "attribute_name");
+		grn_output_null(ctx, &json, type);
+	}
+	PGrnExplainMatchOutputLexiconName(type, lexicon);
+
+	GRN_TEXT_INIT(&matchedTerms, GRN_OBJ_VECTOR);
+
+	grn_output_cstr(ctx, &json, type, "tokens");
+	grn_output_array_open(ctx, &json, type, "tokens", -1);
+
+	tokenCursor = grn_token_cursor_open(ctx,
+										temporaryLexicon,
+										VARDATA_ANY(query),
+										VARSIZE_ANY_EXHDR(query),
+										GRN_TOKEN_ADD,
+										0);
+	PGrnCheck("[explain-match] failed to create token cursor");
+
+	while (grn_token_cursor_get_status(ctx, tokenCursor) ==
+		   GRN_TOKEN_CURSOR_DOING)
+	{
+		grn_id id = grn_token_cursor_next(ctx, tokenCursor);
+		grn_token *token;
+		grn_obj *data;
+		grn_id lexiconID;
+
+		if (id == GRN_ID_NIL)
+			continue;
+
+		token = grn_token_cursor_get_token(ctx, tokenCursor);
+		data = grn_token_get_data(ctx, token);
+		lexiconID = grn_table_get(
+			ctx, lexicon, GRN_TEXT_VALUE(data), GRN_TEXT_LEN(data));
+
+		grn_output_map_open(ctx, &json, type, "token", 6);
+		PGrnExplainMatchOutputText(
+			type, "value", GRN_TEXT_VALUE(data), GRN_TEXT_LEN(data));
+		grn_output_cstr(ctx, &json, type, "position");
+		grn_output_uint32(ctx, &json, type, grn_token_get_position(ctx, token));
+		grn_output_cstr(ctx, &json, type, "source_offset");
+		grn_output_uint64(
+			ctx, &json, type, grn_token_get_source_offset(ctx, token));
+		grn_output_cstr(ctx, &json, type, "source_length");
+		grn_output_uint32(
+			ctx, &json, type, grn_token_get_source_length(ctx, token));
+		grn_output_cstr(ctx, &json, type, "source_first_character_length");
+		grn_output_uint32(ctx,
+						  &json,
+						  type,
+						  grn_token_get_source_first_character_length(ctx,
+																	   token));
+		grn_output_cstr(ctx, &json, type, "in_lexicon");
+		grn_output_bool(ctx, &json, type, lexiconID != GRN_ID_NIL);
+		grn_output_map_close(ctx, &json, type);
+
+		if (lexiconID != GRN_ID_NIL)
+		{
+			grn_vector_add_element(ctx,
+								   &matchedTerms,
+								   GRN_TEXT_VALUE(data),
+								   GRN_TEXT_LEN(data),
+								   0,
+								   GRN_DB_TEXT);
+		}
+	}
+	grn_token_cursor_close(ctx, tokenCursor);
+
+	grn_output_array_close(ctx, &json, type);
+	grn_output_cstr(ctx, &json, type, "matched_terms");
+	{
+		unsigned int i;
+		unsigned int nMatchedTerms = grn_vector_size(ctx, &matchedTerms);
+
+		grn_output_array_open(
+			ctx, &json, type, "matched_terms", nMatchedTerms);
+		for (i = 0; i < nMatchedTerms; i++)
+		{
+			const char *term;
+			unsigned int termSize;
+
+			termSize = grn_vector_get_element(
+				ctx, &matchedTerms, i, &term, NULL, NULL);
+			grn_output_str(ctx, &json, type, term, termSize);
+		}
+	}
+	grn_output_array_close(ctx, &json, type);
+	grn_output_map_close(ctx, &json, type);
+	GRN_TEXT_PUTC(ctx, &json, '\0');
+
+	jsonb = PGrnJSONBParse(GRN_TEXT_VALUE(&json));
+
+	GRN_OBJ_FIN(ctx, &matchedTerms);
+	grn_obj_close(ctx, temporaryLexicon);
+	grn_obj_unref(ctx, lexicon);
+	RelationClose(index);
+	pfree(nulTerminatedIndexName);
+
+	PG_RETURN_JSONB_P(jsonb);
+}

--- a/src/pgrn-explain-match.c
+++ b/src/pgrn-explain-match.c
@@ -95,6 +95,8 @@ pgroonga_explain_match(PG_FUNCTION_ARGS)
 {
 	char *fullIndexName = PG_GETARG_CSTRING(0);
 	text *query = PG_GETARG_TEXT_PP(1);
+	const char *queryRaw = VARDATA_ANY(query);
+	size_t querySize = VARSIZE_ANY_EXHDR(query);
 	const char *indexName;
 	size_t indexNameSize;
 	const char *attributeName;
@@ -164,6 +166,8 @@ pgroonga_explain_match(PG_FUNCTION_ARGS)
 		grn_token *token;
 		grn_obj *data;
 		grn_id lexiconID;
+		uint64_t sourceOffset;
+		uint32_t sourceLength;
 
 		if (id == GRN_ID_NIL)
 			continue;
@@ -172,18 +176,28 @@ pgroonga_explain_match(PG_FUNCTION_ARGS)
 		data = grn_token_get_data(ctx, token);
 		lexiconID = grn_table_get(
 			ctx, lexicon, GRN_TEXT_VALUE(data), GRN_TEXT_LEN(data));
+		sourceOffset = grn_token_get_source_offset(ctx, token);
+		sourceLength = grn_token_get_source_length(ctx, token);
 
-		grn_output_map_open(ctx, &json, type, "token", 6);
+		grn_output_map_open(ctx, &json, type, "token", 7);
 		PGrnExplainMatchOutputText(
 			type, "value", GRN_TEXT_VALUE(data), GRN_TEXT_LEN(data));
+		grn_output_cstr(ctx, &json, type, "source");
+		if (sourceOffset <= querySize && sourceLength <= querySize - sourceOffset)
+		{
+			grn_output_str(
+				ctx, &json, type, queryRaw + sourceOffset, sourceLength);
+		}
+		else
+		{
+			grn_output_null(ctx, &json, type);
+		}
 		grn_output_cstr(ctx, &json, type, "position");
 		grn_output_uint32(ctx, &json, type, grn_token_get_position(ctx, token));
 		grn_output_cstr(ctx, &json, type, "source_offset");
-		grn_output_uint64(
-			ctx, &json, type, grn_token_get_source_offset(ctx, token));
+		grn_output_uint64(ctx, &json, type, sourceOffset);
 		grn_output_cstr(ctx, &json, type, "source_length");
-		grn_output_uint32(
-			ctx, &json, type, grn_token_get_source_length(ctx, token));
+		grn_output_uint32(ctx, &json, type, sourceLength);
 		grn_output_cstr(ctx, &json, type, "source_first_character_length");
 		grn_output_uint32(ctx,
 						  &json,

--- a/src/pgrn-explain-match.h
+++ b/src/pgrn-explain-match.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void PGrnInitializeExplainMatch(void);
+void PGrnFinalizeExplainMatch(void);

--- a/src/pgrn-normalizer-table-variants.c
+++ b/src/pgrn-normalizer-table-variants.c
@@ -1,0 +1,486 @@
+#include "pgroonga.h"
+
+#include "pgrn-groonga.h"
+#include "pgrn-jsonb.h"
+#include "pgrn-pg.h"
+
+#include <catalog/pg_type.h>
+#include <utils/array.h>
+#include <utils/builtins.h>
+
+#include <string.h>
+
+typedef struct
+{
+	char *target;
+	size_t targetSize;
+	char *normalized;
+	size_t normalizedSize;
+} PGrnNormalizerTableVariant;
+
+typedef struct
+{
+	PGrnNormalizerTableVariant *items;
+	size_t nItems;
+	size_t maxNItems;
+} PGrnNormalizerTableVariants;
+
+typedef struct
+{
+	char **items;
+	size_t *sizes;
+	size_t nItems;
+	size_t maxNItems;
+} PGrnNormalizerTableVariantResults;
+
+PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_normalizer_table_variants);
+
+static void
+PGrnNormalizerTableVariantResultsAppend(PGrnNormalizerTableVariantResults *results,
+										const char *variant,
+										size_t variantSize)
+{
+	size_t i;
+
+	for (i = 0; i < results->nItems; i++)
+	{
+		if (results->sizes[i] == variantSize &&
+			memcmp(results->items[i], variant, variantSize) == 0)
+		{
+			return;
+		}
+	}
+
+	if (results->nItems == results->maxNItems)
+	{
+		if (results->maxNItems == 0)
+		{
+			results->maxNItems = 8;
+			results->items = palloc(sizeof(char *) * results->maxNItems);
+			results->sizes = palloc(sizeof(size_t) * results->maxNItems);
+		}
+		else
+		{
+			results->maxNItems *= 2;
+			results->items =
+				repalloc(results->items, sizeof(char *) * results->maxNItems);
+			results->sizes =
+				repalloc(results->sizes, sizeof(size_t) * results->maxNItems);
+		}
+	}
+
+	results->items[results->nItems] = pnstrdup(variant, variantSize);
+	results->sizes[results->nItems] = variantSize;
+	results->nItems++;
+}
+
+static void
+PGrnNormalizerTableVariantsAppend(PGrnNormalizerTableVariants *variants,
+								  const char *target,
+								  size_t targetSize,
+								  const char *normalized,
+								  size_t normalizedSize)
+{
+	if (variants->nItems == variants->maxNItems)
+	{
+		if (variants->maxNItems == 0)
+		{
+			variants->maxNItems = 8;
+			variants->items = palloc(sizeof(PGrnNormalizerTableVariant) *
+									 variants->maxNItems);
+		}
+		else
+		{
+			variants->maxNItems *= 2;
+			variants->items = repalloc(variants->items,
+									   sizeof(PGrnNormalizerTableVariant) *
+										   variants->maxNItems);
+		}
+	}
+
+	variants->items[variants->nItems].target = pnstrdup(target, targetSize);
+	variants->items[variants->nItems].targetSize = targetSize;
+	variants->items[variants->nItems].normalized =
+		pnstrdup(normalized, normalizedSize);
+	variants->items[variants->nItems].normalizedSize = normalizedSize;
+	variants->nItems++;
+}
+
+static bool
+PGrnNormalizerTableParseQuotedArgument(const char **current,
+									   const char *end,
+									   char **value,
+									   size_t *valueSize)
+{
+	const char *start;
+	grn_obj buffer;
+
+	while (*current < end && **current != '"')
+	{
+		(*current)++;
+	}
+	if (*current == end)
+		return false;
+
+	(*current)++;
+	start = *current;
+	GRN_TEXT_INIT(&buffer, 0);
+	while (*current < end)
+	{
+		if (**current == '\\')
+		{
+			GRN_TEXT_PUT(ctx, &buffer, start, *current - start);
+			(*current)++;
+			if (*current == end)
+				break;
+			GRN_TEXT_PUT(ctx, &buffer, *current, 1);
+			(*current)++;
+			start = *current;
+		}
+		else if (**current == '"')
+		{
+			GRN_TEXT_PUT(ctx, &buffer, start, *current - start);
+			*value = pnstrdup(GRN_TEXT_VALUE(&buffer), GRN_TEXT_LEN(&buffer));
+			*valueSize = GRN_TEXT_LEN(&buffer);
+			GRN_OBJ_FIN(ctx, &buffer);
+			(*current)++;
+			return true;
+		}
+		else
+		{
+			(*current)++;
+		}
+	}
+
+	GRN_OBJ_FIN(ctx, &buffer);
+	return false;
+}
+
+static bool
+PGrnNormalizerTableParse(const char *normalizers,
+						 size_t normalizersSize,
+						 char **normalizedColumnObjectName,
+						 size_t *normalizedColumnObjectNameSize,
+						 char **targetColumnName,
+						 size_t *targetColumnNameSize)
+{
+	const char normalizerTable[] = "NormalizerTable";
+	const size_t normalizerTableSize = sizeof(normalizerTable) - 1;
+	const char *current = normalizers;
+	const char *end = normalizers + normalizersSize;
+	char *arguments[4] = {NULL, NULL, NULL, NULL};
+	size_t argumentSizes[4] = {0, 0, 0, 0};
+	size_t i;
+
+	while (current + normalizerTableSize < end)
+	{
+		if (memcmp(current, normalizerTable, normalizerTableSize) == 0)
+			break;
+		current++;
+	}
+	if (current + normalizerTableSize >= end)
+		return false;
+
+	current += normalizerTableSize;
+	while (current < end && *current != '(')
+		current++;
+	if (current == end)
+		return false;
+	current++;
+
+	for (i = 0; i < 4; i++)
+	{
+		if (!PGrnNormalizerTableParseQuotedArgument(
+				&current, end, &(arguments[i]), &(argumentSizes[i])))
+		{
+			return false;
+		}
+	}
+
+	*normalizedColumnObjectName = arguments[1];
+	*normalizedColumnObjectNameSize = argumentSizes[1];
+	*targetColumnName = arguments[3];
+	*targetColumnNameSize = argumentSizes[3];
+	return true;
+}
+
+static int
+PGrnNormalizerTableResolveLexiconIndex(Relation index)
+{
+	int i;
+
+	for (i = 0; i < index->rd_att->natts; i++)
+	{
+		grn_obj *lexicon = PGrnLookupLexicon(index, i, ERROR);
+		bool isTextLexicon =
+			grn_type_id_is_text_family(ctx, lexicon->header.domain);
+		grn_obj_unref(ctx, lexicon);
+		if (isTextLexicon)
+			return i;
+	}
+
+	ereport(ERROR,
+			(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+			 errmsg("pgroonga: [normalizer-table-variants] "
+					"index doesn't have a lexicon for text: <%s>",
+					RelationGetRelationName(index))));
+	return -1;
+}
+
+static void
+PGrnNormalizerTableLoadVariants(PGrnNormalizerTableVariants *variants,
+								grn_obj *normalizationTable,
+								grn_obj *normalizedColumn,
+								grn_obj *targetColumn)
+{
+	grn_table_cursor *cursor;
+	grn_id id;
+	grn_id normalizedRangeID;
+	grn_id targetRangeID;
+	grn_obj normalizedValue;
+	grn_obj targetValue;
+	grn_obj normalizedText;
+	grn_obj targetText;
+
+	normalizedRangeID = grn_obj_get_range(ctx, normalizedColumn);
+	targetRangeID = grn_obj_get_range(ctx, targetColumn);
+	GRN_VOID_INIT(&normalizedValue);
+	GRN_VOID_INIT(&targetValue);
+	grn_obj_reinit(ctx, &normalizedValue, normalizedRangeID, 0);
+	grn_obj_reinit(ctx, &targetValue, targetRangeID, 0);
+	GRN_TEXT_INIT(&normalizedText, 0);
+	GRN_TEXT_INIT(&targetText, 0);
+
+	cursor = grn_table_cursor_open(
+		ctx, normalizationTable, NULL, 0, NULL, 0, 0, -1, 0);
+	if (!cursor)
+	{
+		PGrnCheckRC(GRN_NO_MEMORY_AVAILABLE,
+					"[normalizer-table-variants] failed to create cursor");
+	}
+
+	while ((id = grn_table_cursor_next(ctx, cursor)) != GRN_ID_NIL)
+	{
+		GRN_BULK_REWIND(&normalizedValue);
+		GRN_BULK_REWIND(&targetValue);
+		GRN_BULK_REWIND(&normalizedText);
+		GRN_BULK_REWIND(&targetText);
+		grn_obj_get_value(ctx, normalizedColumn, id, &normalizedValue);
+		grn_obj_get_value(ctx, targetColumn, id, &targetValue);
+		if (grn_type_id_is_text_family(ctx, normalizedRangeID))
+		{
+			GRN_TEXT_PUT(ctx,
+						 &normalizedText,
+						 GRN_TEXT_VALUE(&normalizedValue),
+						 GRN_TEXT_LEN(&normalizedValue));
+		}
+		else if (grn_id_maybe_table(ctx, normalizedRangeID))
+		{
+			grn_obj *rangeTable = grn_ctx_at(ctx, normalizedRangeID);
+			char key[GRN_TABLE_MAX_KEY_SIZE];
+			int keySize = grn_table_get_key(
+				ctx, rangeTable, GRN_RECORD_VALUE(&normalizedValue), key, sizeof(key));
+			GRN_TEXT_PUT(ctx, &normalizedText, key, keySize);
+			grn_obj_unref(ctx, rangeTable);
+		}
+		if (grn_type_id_is_text_family(ctx, targetRangeID))
+		{
+			GRN_TEXT_PUT(ctx,
+						 &targetText,
+						 GRN_TEXT_VALUE(&targetValue),
+						 GRN_TEXT_LEN(&targetValue));
+		}
+		else if (grn_id_maybe_table(ctx, targetRangeID))
+		{
+			grn_obj *rangeTable = grn_ctx_at(ctx, targetRangeID);
+			char key[GRN_TABLE_MAX_KEY_SIZE];
+			int keySize = grn_table_get_key(
+				ctx, rangeTable, GRN_RECORD_VALUE(&targetValue), key, sizeof(key));
+			GRN_TEXT_PUT(ctx, &targetText, key, keySize);
+			grn_obj_unref(ctx, rangeTable);
+		}
+		if (GRN_TEXT_LEN(&normalizedText) == 0 || GRN_TEXT_LEN(&targetText) == 0)
+		{
+			continue;
+		}
+		PGrnNormalizerTableVariantsAppend(variants,
+										  GRN_TEXT_VALUE(&targetText),
+										  GRN_TEXT_LEN(&targetText),
+										  GRN_TEXT_VALUE(&normalizedText),
+										  GRN_TEXT_LEN(&normalizedText));
+	}
+
+	grn_table_cursor_close(ctx, cursor);
+	GRN_OBJ_FIN(ctx, &normalizedValue);
+	GRN_OBJ_FIN(ctx, &targetValue);
+	GRN_OBJ_FIN(ctx, &normalizedText);
+	GRN_OBJ_FIN(ctx, &targetText);
+}
+
+static void
+PGrnNormalizerTableVariantsExpand(PGrnNormalizerTableVariants *variants,
+								  const char *normalized,
+								  size_t normalizedSize,
+								  grn_obj *prefix,
+								  PGrnNormalizerTableVariantResults *results)
+{
+	size_t i;
+	bool expanded = false;
+
+	if (normalizedSize == 0)
+	{
+		PGrnNormalizerTableVariantResultsAppend(results,
+												GRN_TEXT_VALUE(prefix),
+												GRN_TEXT_LEN(prefix));
+		return;
+	}
+
+	for (i = 0; i < variants->nItems; i++)
+	{
+		PGrnNormalizerTableVariant *variant = &(variants->items[i]);
+		size_t originalPrefixSize;
+
+		if (variant->normalizedSize > normalizedSize)
+			continue;
+		if (memcmp(normalized, variant->normalized, variant->normalizedSize) != 0)
+			continue;
+
+		originalPrefixSize = GRN_TEXT_LEN(prefix);
+		GRN_TEXT_PUT(ctx, prefix, variant->target, variant->targetSize);
+		PGrnNormalizerTableVariantsExpand(
+			variants,
+			normalized + variant->normalizedSize,
+			normalizedSize - variant->normalizedSize,
+			prefix,
+			results);
+		GRN_BULK_SET_CURR(prefix, GRN_BULK_HEAD(prefix) + originalPrefixSize);
+		expanded = true;
+	}
+
+	{
+		int charLength = grn_charlen(ctx, normalized, normalized + normalizedSize);
+		size_t originalPrefixSize;
+		if (charLength <= 0)
+			return;
+		originalPrefixSize = GRN_TEXT_LEN(prefix);
+		GRN_TEXT_PUT(ctx, prefix, normalized, charLength);
+		PGrnNormalizerTableVariantsExpand(variants,
+										  normalized + charLength,
+										  normalizedSize - charLength,
+										  prefix,
+										  results);
+		GRN_BULK_SET_CURR(prefix, GRN_BULK_HEAD(prefix) + originalPrefixSize);
+	}
+
+	(void) expanded;
+}
+
+/**
+ * pgroonga_normalizer_table_variants(indexName cstring, normalized text) :
+ * text[]
+ */
+Datum
+pgroonga_normalizer_table_variants(PG_FUNCTION_ARGS)
+{
+	char *indexName = PG_GETARG_CSTRING(0);
+	text *normalized = PG_GETARG_TEXT_PP(1);
+	Relation index;
+	int lexiconIndex;
+	grn_obj *lexicon;
+	grn_obj normalizers;
+	char *normalizedColumnObjectName = NULL;
+	size_t normalizedColumnObjectNameSize = 0;
+	char *targetColumnName = NULL;
+	size_t targetColumnNameSize = 0;
+	const char *separator;
+	size_t tableNameSize;
+	grn_obj *normalizationTable;
+	grn_obj *normalizedColumn;
+	grn_obj *targetColumn;
+	PGrnNormalizerTableVariants variants = {NULL, 0, 0};
+	PGrnNormalizerTableVariantResults results = {NULL, NULL, 0, 0};
+	grn_obj prefix;
+	Datum *datums;
+	ArrayType *array;
+	size_t i;
+
+	index = PGrnPGResolveIndexName(indexName);
+	lexiconIndex = PGrnNormalizerTableResolveLexiconIndex(index);
+	lexicon = PGrnLookupLexicon(index, lexiconIndex, ERROR);
+
+	GRN_TEXT_INIT(&normalizers, 0);
+	grn_table_get_normalizers_string(ctx, lexicon, &normalizers);
+	PGrnCheck("[normalizer-table-variants] failed to get normalizers");
+	if (!PGrnNormalizerTableParse(GRN_TEXT_VALUE(&normalizers),
+								  GRN_TEXT_LEN(&normalizers),
+								  &normalizedColumnObjectName,
+								  &normalizedColumnObjectNameSize,
+								  &targetColumnName,
+								  &targetColumnNameSize))
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("pgroonga: [normalizer-table-variants] "
+						"index doesn't use NormalizerTable: <%s>",
+						RelationGetRelationName(index))));
+	}
+
+	separator = normalizedColumnObjectName + normalizedColumnObjectNameSize;
+	while (separator > normalizedColumnObjectName && separator[-1] != '.')
+		separator--;
+	if (separator == normalizedColumnObjectName)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+				 errmsg("pgroonga: [normalizer-table-variants] "
+						"invalid NormalizerTable column: <%.*s>",
+						(int) normalizedColumnObjectNameSize,
+						normalizedColumnObjectName)));
+	}
+
+	tableNameSize = (separator - normalizedColumnObjectName) - 1;
+	normalizationTable =
+		PGrnLookupWithSize(normalizedColumnObjectName, tableNameSize, ERROR);
+	normalizedColumn =
+		PGrnLookupColumnWithSize(normalizationTable,
+								 separator,
+								 normalizedColumnObjectNameSize - tableNameSize - 1,
+								 ERROR);
+	targetColumn = PGrnLookupColumnWithSize(
+		normalizationTable, targetColumnName, targetColumnNameSize, ERROR);
+
+	PGrnNormalizerTableLoadVariants(
+		&variants, normalizationTable, normalizedColumn, targetColumn);
+
+	GRN_TEXT_INIT(&prefix, 0);
+	PGrnNormalizerTableVariantsExpand(&variants,
+									  VARDATA_ANY(normalized),
+									  VARSIZE_ANY_EXHDR(normalized),
+									  &prefix,
+									  &results);
+	GRN_OBJ_FIN(ctx, &prefix);
+
+	if (results.nItems == 0)
+	{
+		array = construct_empty_array(TEXTOID);
+	}
+	else
+	{
+		datums = palloc(sizeof(Datum) * results.nItems);
+		for (i = 0; i < results.nItems; i++)
+		{
+			datums[i] = PointerGetDatum(
+				cstring_to_text_with_len(results.items[i], results.sizes[i]));
+		}
+		array = construct_array(datums, results.nItems, TEXTOID, -1, false, 'i');
+	}
+
+	grn_obj_unref(ctx, targetColumn);
+	grn_obj_unref(ctx, normalizedColumn);
+	grn_obj_unref(ctx, normalizationTable);
+	GRN_OBJ_FIN(ctx, &normalizers);
+	grn_obj_unref(ctx, lexicon);
+	RelationClose(index);
+
+	PG_RETURN_ARRAYTYPE_P(array);
+}

--- a/src/pgrn-normalizer-table-variants.h
+++ b/src/pgrn-normalizer-table-variants.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -11,6 +11,7 @@
 #include "pgrn-create.h"
 #include "pgrn-ctid.h"
 #include "pgrn-custom-scan.h"
+#include "pgrn-explain-match.h"
 #include "pgrn-file.h"
 #include "pgrn-global.h"
 #include "pgrn-groonga-tuple-is-alive.h"
@@ -448,6 +449,9 @@ PGrnBeforeShmemExit(int code, Datum arg)
 			GRN_LOG(ctx, GRN_LOG_DEBUG, "%s[finalize][normalize]", tag);
 			PGrnFinalizeNormalize();
 
+			GRN_LOG(ctx, GRN_LOG_DEBUG, "%s[finalize][explain-match]", tag);
+			PGrnFinalizeExplainMatch();
+
 			GRN_LOG(ctx, GRN_LOG_DEBUG, "%s[finalize][tokenize]", tag);
 			PGrnFinalizeTokenize();
 
@@ -588,6 +592,8 @@ PGrnInitializeDatabase(void)
 	PGrnInitializeTokenize();
 
 	PGrnInitializeNormalize();
+
+	PGrnInitializeExplainMatch();
 
 	PGrnInitializeLanguageModelVectorize();
 

--- a/test/run-sql-test.sh
+++ b/test/run-sql-test.sh
@@ -28,17 +28,17 @@ while [ $# -gt 0 ]; do
         touch ${expected_path}
       fi
       mkdir -p ${BUILD_DIR}/results/$(dirname ${test_name})
-      test_names="${test_names[@]} ${test_name}"
+      test_names="${test_names} ${test_name}"
       ;;
     *)
       if [ -d "${arg}" ]; then
         for test_path in $(find ${arg} -name "*.sql"); do
           test_name=$(echo "${test_path}" | sed -E -e 's,^sql/|\.sql,,g')
           mkdir -p ${BUILD_DIR}/results/$(dirname ${test_name})
-          test_names="${test_names[@]} ${test_name}"
+          test_names="${test_names} ${test_name}"
         done
       else
-        test_names="${test_names[@]} ${arg}"
+        test_names="${test_names} ${arg}"
       fi
       ;;
   esac


### PR DESCRIPTION
## Summary

  Add `pgroonga_explain_match(indexName cstring, query text)` to show how a query term is tokenized/normalized
  against a PGroonga index lexicon.

  **日本語:**
  `pgroonga_explain_match(indexName cstring, query text)` を追加し、検索語がPGroongaのインデックスLexiconに対してど
  のようにトークナイズ・正規化されるかを可視化できるようにします。

#### 「なんでこれでヒットすんのよ？」を分かりやすく見せるようのニッチな機能。

  ## Changes

  - Add a new SQL function:
    - `pgroonga_explain_match(indexName cstring, query text) RETURNS jsonb`
  - Add C implementation:
    - Creates a temporary lexicon that copies the target index lexicon settings
    - Tokenizes the given query with the same tokenizer/normalizers/token filters as the target index
    - Checks whether each generated token exists in the real index lexicon
    - Returns both all generated tokens and matched lexicon terms as JSONB
  - Support index column selection:
    - `pgroonga_explain_match('index_name', 'query')`
    - `pgroonga_explain_match('index_name.column_name', 'query')`
  - Register the new source file in Meson build
  - Initialize/finalize the new explain-match module in PGroonga lifecycle
  - Add regression tests for:
    - Basic token explanation
    - Romaji normalization with `NormalizerNFKC150("unify_to_romaji", true)`
    - Search result comparison for normalized Japanese/Katakana/Romaji behavior

  **日本語:**

  - 新しいSQL関数を追加:
    - `pgroonga_explain_match(indexName cstring, query text) RETURNS jsonb`
  - C実装を追加:
    - 対象インデックスのLexicon設定をコピーした一時Lexiconを作成
    - 対象インデックスと同じTokenizer/Normalizer/TokenFilterで検索語をトークナイズ
    - 生成された各トークンが実際のインデックスLexiconに存在するかを確認
    - 生成された全トークンと、実Lexiconに存在した語をJSONBで返却
  - インデックスカラム指定をサポート:
    - `pgroonga_explain_match('index_name', 'query')`
    - `pgroonga_explain_match('index_name.column_name', 'query')`
  - 新規CファイルをMesonビルド対象に追加
  - PGroongaの初期化/終了処理に explain-match モジュールを接続
  - 回帰テストを追加:
    - 基本的なトークン説明
    - `NormalizerNFKC150("unify_to_romaji", true)` によるローマ字正規化
    - 日本語/カタカナ/ローマ字正規化時の検索結果確認

  ## Example

  Given this index:

  ```sql
  CREATE INDEX pgroonga_content_search_index ON memos USING pgroonga (content)
    WITH (
      normalizers = 'NormalizerNFKC150(
                       "unify_to_romaji", true,
                       "unify_hyphen_and_prolonged_sound_mark", true
                     )',
      tokenizer='TokenNgram(
                   "unify_alphabet", false,
                   "unify_symbol", false,
                   "unify_digit", false,
                   "report_source_location", true
                 )'
    );

  A normal search can match both Hiragana and Katakana forms:

  SELECT id, content
    FROM memos
   WHERE content &@ 'すごい'
   ORDER BY id;

  Result:

  id|content
  1|すごいでしょう
  2|スゴイデショウ

  You can inspect why the query matches:

  SELECT pgroonga_explain_match('pgroonga_content_search_index', 'すごい');

  Example output:

  {
    "query": "すごい",
    "index_name": "pgroonga_content_search_index",
    "attribute_name": null,
    "lexicon_name": "Lexicon...",
    "tokens": [
      {"value": "su", "position": 0, "in_lexicon": true},
      {"value": "ug", "position": 1, "in_lexicon": true},
      {"value": "go", "position": 2, "in_lexicon": true},
      {"value": "oi", "position": 3, "in_lexicon": true},
      {"value": "i", "position": 4, "in_lexicon": false}
    ],
    "matched_terms": ["su", "ug", "go", "oi"]
  }

  This shows that すごい is normalized/tokenized into romaji N-gram terms such as su, ug, go, and oi, and those
  terms exist in the actual index lexicon.

  Another example with query syntax:

  SELECT id, content
    FROM memos
   WHERE title &@~ 'デス'
   ORDER BY id;

  Result:

  id|content
  1|すごいでしょう
  2|スゴイデショウ
  3|ハバナイスデー

  Explanation:

  SELECT token->>'value' AS value,
         token->>'position' AS position,
         token->>'in_lexicon' AS in_lexicon
    FROM jsonb_array_elements(
      pgroonga_explain_match('pgroonga_title_search_index', 'デス')->'tokens'
    ) AS token;

  Output:

  value|position|in_lexicon
  de|0|true
  es|1|true
  su|2|true
  u|3|false

  ## Tests

  BUILD_DIR=build NEED_SUDO=no HAVE_XXHASH=1 TEMP_INSTANCE=build/db-explain-match \
    bash test/run-sql-test.sh function/explain-match/token function/explain-match/romaji

  Result:

  ok 1 - function/explain-match/token
  ok 2 - function/explain-match/romaji
  # All 2 tests passed.
