### PR TITLE
Fix a crash when an UPDATE statement with a WHERE clause and VACUUM are executed concurrently

### DIFF
--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -830,12 +830,6 @@ PGrnEnsureLatestDB(void)
 		return false;
 	}
 
-	if (PGrnNScanOpaques != 0)
-	{
-		PGRN_TRACE_LOG_EXIT();
-		return false;
-	}
-
 	GRN_LOG(
 		ctx, GRN_LOG_DEBUG, "pgroonga: unmap DB because VACUUM was executed");
 	PGrnUnmapDB();
@@ -5190,7 +5184,10 @@ pgroonga_insert(Relation index,
 						tag)));
 	}
 
-	PGrnEnsureLatestDB();
+	if (PGrnNScanOpaques == 0)
+	{
+		PGrnEnsureLatestDB();
+	}
 
 	PGrnWALApply(index);
 

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -100,11 +100,11 @@ static bool PGrnBaseInitialized = false;
 bool PGrnGroongaInitialized = false;
 static bool PGrnCrashSaferInitialized = false;
 bool PGrnEnableParallelBuildCopy = false;
+static bool PGrnIsScanning = false;
 
 typedef struct PGrnProcessSharedData
 {
 	TimestampTz lastVacuumTimestamp;
-	pg_atomic_uint32 nScanningProcesses;
 } PGrnProcessSharedData;
 
 typedef struct PGrnProcessLocalData
@@ -729,8 +729,8 @@ _PG_init(void)
 			if (!found)
 			{
 				processSharedData->lastVacuumTimestamp = GetCurrentTimestamp();
-				pg_atomic_init_u32(&(processSharedData->nScanningProcesses), 0);
 			}
+			PGrnIsScanning = false;
 			LWLockRelease(AddinShmemInitLock);
 		}
 		processLocalData.lastDBUnmapTimestamp = GetCurrentTimestamp();
@@ -833,7 +833,7 @@ PGrnEnsureLatestDB(void)
 		return false;
 	}
 
-	if (pg_atomic_read_u32(&(processSharedData->nScanningProcesses)) != 0)
+	if (PGrnIsScanning)
 	{
 		PGRN_TRACE_LOG_EXIT();
 		return false;
@@ -5472,10 +5472,7 @@ pgroonga_beginscan(Relation index, int nKeys, int nOrderBys)
 	 * PGrnEnsureLatestDB() comment for details. */
 	/* PGrnEnsureLatestDB(); */
 
-	if (processSharedData)
-	{
-		pg_atomic_fetch_add_u32(&(processSharedData->nScanningProcesses), 1);
-	}
+	PGrnIsScanning = true;
 
 	scan = RelationGetIndexScan(index, nKeys, nOrderBys);
 
@@ -7789,10 +7786,7 @@ pgroonga_endscan(IndexScanDesc scan)
 	PGrnScanOpaqueFin(so);
 	MemoryContextDelete(memoryContext);
 
-	if (processSharedData)
-	{
-		pg_atomic_fetch_sub_u32(&(processSharedData->nScanningProcesses), 1);
-	}
+	PGrnIsScanning = false;
 
 	PGRN_TRACE_LOG_EXIT();
 }

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -79,7 +79,6 @@
 #include <groonga.h>
 
 #include <math.h>
-#include <port/atomics.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -100,7 +100,6 @@ static bool PGrnBaseInitialized = false;
 bool PGrnGroongaInitialized = false;
 static bool PGrnCrashSaferInitialized = false;
 bool PGrnEnableParallelBuildCopy = false;
-static bool PGrnIsScanning = false;
 
 typedef struct PGrnProcessSharedData
 {
@@ -730,7 +729,6 @@ _PG_init(void)
 			{
 				processSharedData->lastVacuumTimestamp = GetCurrentTimestamp();
 			}
-			PGrnIsScanning = false;
 			LWLockRelease(AddinShmemInitLock);
 		}
 		processLocalData.lastDBUnmapTimestamp = GetCurrentTimestamp();
@@ -833,7 +831,7 @@ PGrnEnsureLatestDB(void)
 		return false;
 	}
 
-	if (PGrnIsScanning)
+	if (PGrnNScanOpaques != 0)
 	{
 		PGRN_TRACE_LOG_EXIT();
 		return false;
@@ -5472,8 +5470,6 @@ pgroonga_beginscan(Relation index, int nKeys, int nOrderBys)
 	 * PGrnEnsureLatestDB() comment for details. */
 	/* PGrnEnsureLatestDB(); */
 
-	PGrnIsScanning = true;
-
 	scan = RelationGetIndexScan(index, nKeys, nOrderBys);
 
 	so = (PGrnScanOpaque) malloc(sizeof(PGrnScanOpaqueData));
@@ -7785,8 +7781,6 @@ pgroonga_endscan(IndexScanDesc scan)
 
 	PGrnScanOpaqueFin(so);
 	MemoryContextDelete(memoryContext);
-
-	PGrnIsScanning = false;
 
 	PGRN_TRACE_LOG_EXIT();
 }

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -5184,6 +5184,31 @@ pgroonga_insert(Relation index,
 						tag)));
 	}
 
+	/*
+	 * pgroonga_insert() may be called between pgroonga_beginscan() and
+	 * pgroonga_endscan() while executing an UPDATE statement with a WHERE
+	 * clause.
+	 * If an UPDATE statement with a WHERE clause and VACUUM are executed
+	 * concurrently, EnsureLatestDB() may be called in this scope, as shown
+	 * below:
+	 *
+	 * pgroonga: [trace][pgroonga_beginscan][enter]
+	 * pgroonga: [trace][pgroonga_beginscan][exit]
+	 * pgroonga: [trace][pgroonga_rescan][enter]
+	 * pgroonga: [trace][pgroonga_rescan][exit]
+	 * pgroonga: [trace][pgroonga_insert][enter]
+	 * pgroonga: [trace][PGrnEnsureLatestDB][enter]
+	 * pgroonga: [trace][PGrnUnmapDB][enter]
+	 * pgroonga: [trace][PGrnUnmapDB][exit]
+	 * pgroonga: [trace][PGrnEnsureLatestDB][exit]
+	 * pgroonga: [trace][pgroonga_insert][exit]
+	 * pgroonga: [trace][pgroonga_endscan][enter]
+	 * pgroonga: [trace][pgroonga_endscan][exit]
+	 *
+	 * EnsureLatestDB() should not be called in this scope.
+	 * See the comment for PGrnEnsureLatestDB() for detail.
+	 * Therefore, prevent EnsureLatestDB() from being called while between
+	 * pgroonga_beginscan() and pgroonga_endscan. */
 	if (PGrnNScanOpaques == 0)
 	{
 		PGrnEnsureLatestDB();

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -79,6 +79,7 @@
 #include <groonga.h>
 
 #include <math.h>
+#include <port/atomics.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -103,6 +104,7 @@ bool PGrnEnableParallelBuildCopy = false;
 typedef struct PGrnProcessSharedData
 {
 	TimestampTz lastVacuumTimestamp;
+	pg_atomic_uint32 nScanningProcesses;
 } PGrnProcessSharedData;
 
 typedef struct PGrnProcessLocalData
@@ -727,6 +729,7 @@ _PG_init(void)
 			if (!found)
 			{
 				processSharedData->lastVacuumTimestamp = GetCurrentTimestamp();
+				pg_atomic_init_u32(&(processSharedData->nScanningProcesses), 0);
 			}
 			LWLockRelease(AddinShmemInitLock);
 		}
@@ -825,6 +828,12 @@ PGrnEnsureLatestDB(void)
 
 	if (processLocalData.lastDBUnmapTimestamp >
 		processSharedData->lastVacuumTimestamp)
+	{
+		PGRN_TRACE_LOG_EXIT();
+		return false;
+	}
+
+	if (pg_atomic_read_u32(&(processSharedData->nScanningProcesses)) != 0)
 	{
 		PGRN_TRACE_LOG_EXIT();
 		return false;
@@ -5463,6 +5472,11 @@ pgroonga_beginscan(Relation index, int nKeys, int nOrderBys)
 	 * PGrnEnsureLatestDB() comment for details. */
 	/* PGrnEnsureLatestDB(); */
 
+	if (processSharedData)
+	{
+		pg_atomic_fetch_add_u32(&(processSharedData->nScanningProcesses), 1);
+	}
+
 	scan = RelationGetIndexScan(index, nKeys, nOrderBys);
 
 	so = (PGrnScanOpaque) malloc(sizeof(PGrnScanOpaqueData));
@@ -7774,6 +7788,11 @@ pgroonga_endscan(IndexScanDesc scan)
 
 	PGrnScanOpaqueFin(so);
 	MemoryContextDelete(memoryContext);
+
+	if (processSharedData)
+	{
+		pg_atomic_fetch_sub_u32(&(processSharedData->nScanningProcesses), 1);
+	}
 
 	PGRN_TRACE_LOG_EXIT();
 }


### PR DESCRIPTION
We should not call EnsureLatestDB() between pgroonga_beginscan() and pgroonga_endscan() according to the comment for PGrnEnsureLatestDB() in https://github.com/pgroonga/pgroonga/blob/4.0.6/src/pgroonga.c#L792-L814.
In fact, a PGroonga process does not detect a VACUUM executed by another process and does not call EnsureLatestDB() in this scope.

However, an UPDATE statement with a WHERE clause may call pgroonga_insert() in this scope as below:

```
pgroonga: [trace][pgroonga_beginscan][enter]
pgroonga: [trace][pgroonga_beginscan][exit]
pgroonga: [trace][pgroonga_rescan][enter]
pgroonga: [trace][pgroonga_rescan][exit]
pgroonga: [trace][pgroonga_insert][enter]
pgroonga: [trace][PGrnEnsureLatestDB][enter]
pgroonga: [trace][PGrnEnsureLatestDB][exit]
pgroonga: [trace][pgroonga_insert][exit]
pgroonga: [trace][pgroonga_endscan][enter]
pgroonga: [trace][pgroonga_endscan][exit]
```

pgroonga_insert() detects execution of VACUUM and close the opened grn_obj by calling PGrnUnmapDB().
Therefore, if an UPDATE statement with a WHERE clause and VACUUM are executed concurrently, PGronga close the opened grn_obj between pgroonga_beginscan() and pgroonga_endscan() as below:

```
pgroonga: [trace][pgroonga_beginscan][enter]
pgroonga: [trace][pgroonga_beginscan][exit]
pgroonga: [trace][pgroonga_rescan][enter]
pgroonga: [trace][pgroonga_rescan][exit]
pgroonga: [trace][pgroonga_insert][enter]
pgroonga: [trace][PGrnEnsureLatestDB][enter]
pgroonga: [trace][PGrnUnmapDB][enter]
pgroonga: [trace][PGrnUnmapDB][exit]
pgroonga: [trace][PGrnEnsureLatestDB][exit]
pgroonga: [trace][pgroonga_insert][exit]
pgroonga: [trace][pgroonga_endscan][enter]
pgroonga: [trace][pgroonga_endscan][exit]
```

We add a condition to prevent PGrnEnsureLatestDB() from being executed while between pgroonga_beginscan() and pgroonga_endscan in this modification.
With the change, PGroonga will no longer crash even in the scenario described above.
