### PR TITLE
ci: add workflow trigger for maintenance branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - "maintenance/*"
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - "maintenance/*"
     tags:
       - "*"
   pull_request:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - "maintenance/*"
     tags:
       - "*"
   pull_request:


### PR DESCRIPTION
Apply this trigger only lint, linux, and package workflows.
Because only the PGroonga package for PostgreSQL 12 on AlmaLinux 8 is needed in the maintenance/3.2.2 branch.
maintenance package does not necessary in macos, windows, and setup workflow.