### PR TITLE
packages yum: pin Groonga version and Apache Arrow version for building maintenance package

### DIFF
--- a/packages/pgroonga-package-task.rb
+++ b/packages/pgroonga-package-task.rb
@@ -23,7 +23,7 @@ class GenericPGroongaPackageTask < PackagesGroongaOrgPackageTask
   # This function only use YUM packages.
   # Only the PGroonga package for PostgreSQL 12 on AlmaLinux 8 is needed in the maintenance/3.2.2 branch.
   def maintenance_groonga_version
-    "v14.0.6"
+    "14.0.6"
   end
 
   def latest_groonga_version

--- a/packages/pgroonga-package-task.rb
+++ b/packages/pgroonga-package-task.rb
@@ -18,6 +18,14 @@ class GenericPGroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   private
+  # We use a fixed Groonga version for maintenance in the maintenance/3.2.2 branch.
+  # This is because Groonga was at version 14.0.6 when 3.2.2 was built.
+  # This function only use YUM packages.
+  # Only the PGroonga package for PostgreSQL 12 on AlmaLinux 8 is needed in the maintenance/3.2.2 branch.
+  def maintenance_groonga_version
+    "v14.0.6"
+  end
+
   def latest_groonga_version
     @latest_groonga_version ||= Helper.detect_latest_groonga_version
   end
@@ -87,7 +95,7 @@ class GenericPGroongaPackageTask < PackagesGroongaOrgPackageTask
     when "PG_PACKAGE_VERSION"
       @postgresql_package_version
     when "GROONGA_VERSION"
-      latest_groonga_version
+      maintenance_groonga_version
     else
       super
     end

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,6 +22,9 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
+    # If we do not pin the version of groonga-devel, groonga-devel uses the latest available version(16.0.5).
+    # However, this branch uses PGroonga version 3.2.2, which was built with Groonga 14.0.6.
+    # Therefore, we pin groonga-devel to 14.0.6 to ensure compatibility.
     groonga-devel-14.0.6-1.el8.x86_64 \
     llvm-toolset \
     llvm-devel \

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
-    groonga-devel \
+    groonga-devel-14.0.6-1.el8.x86_64 \
     llvm-toolset \
     llvm-devel \
     msgpack-devel \

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,6 +22,12 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
+    # Normally, both arrow-devel and arrow-libs are installed automatically as dependency of groonga-devel.
+    # However, when installed this way, the latest version(24.0.0) is also installed even if we pin groonga-devel to 14.0.6.
+    # We want to restrict their versions to 16.1.0 to ensure compatibility.
+    # We can install them at version 16.1.0 by pinning them to 16.1.0 when the packages are installed.
+    arrow-devel-16.1.0-1.el8.x86_64 \
+    arrow16-libs-16.1.0-1.el8.x86_64 \
     # If we do not pin the version of groonga-devel, groonga-devel uses the latest available version(16.0.5).
     # However, this branch uses PGroonga version 3.2.2, which was built with Groonga 14.0.6.
     # Therefore, we pin groonga-devel to 14.0.6 to ensure compatibility.


### PR DESCRIPTION
We use a fixed Groonga version for maintenance in the maintenance/3.2.2 branch.
This is because Groonga was at version 14.0.6 when 3.2.2 was built.
This function only use YUM packages.
Only the PGroonga package for PostgreSQL 12 on AlmaLinux 8 is needed in the maintenance/3.2.2 branch.

If we do not pin `GROONGA_VERSION`, postgresql12-pgdg-pgroonga-3.2.2-2 require the latest version of groonga-devel as dependency package:

```
groonga-devel >= 16.0.5 is needed by postgresql12-pgdg-pgroonga-3.2.2-2.el8.x86_64
```

However, we should use groonga-devel 14.0.6 to ensure compatibility.
Therefore, we pin Groonga_VERSION to 14.0.6 in this midification.

---

Normally, both arrow-devel and arrow-libs are installed automatically as dependency of groonga-devel.
However, when installed this way, the latest version(24.0.0) is also installed even if we pin groonga-devel to 14.0.6 as shown below:

```
#8 73.00 AlmaLinux 8 - PowerTools                         11 MB/s | 6.2 MB     00:00    
#8 74.16 Last metadata expiration check: 0:00:02 ago on Thu Jul  2 00:43:07 2026.
#8 76.53 Dependencies resolved.
#8 76.53 ==============================================================================================================
#8 76.53  Package                          Arch    Version                                Repository               Size
#8 76.53 ==============================================================================================================
#8 76.53 Installing:
#8 76.53  ccache                           x86_64  3.7.7-1.el8                            epel                    232 k
#8 76.53  groonga-devel                    x86_64  14.0.6-1.el8                           groonga-almalinux        78 k
#8 76.53  llvm-devel                       x86_64  21.1.8-1.module_el8.10.0+4172+b6b13d75 appstream               5.7 M
#8 76.53  llvm-toolset                     x86_64  21.1.8-1.module_el8.10.0+4172+b6b13d75 appstream                42 k
#8 76.53  msgpack-devel                    x86_64  3.1.0-3.el8                            epel                    308 k
#8 76.53  postgresql12-devel               x86_64  12.22-1PGDG.rhel8                      pgdg12-archive          2.3 M
#8 76.53  xxhash-devel                     x86_64  0.8.2-1.el8                            powertools               62 k
#8 76.53 Installing dependencies:
#8 76.53  arrow-devel                      x86_64  24.0.0-1.el8                           apache-arrow-almalinux   14 M
#8 76.53  arrow16-libs                     x86_64  16.1.0-1.el8                           apache-arrow-almalinux  7.8 M
#8 76.53  arrow2400-libs                   x86_64  24.0.0-1.el8                           apache-arrow-almalinux  7.3 M
```

We want to restrict their versions to 16.1.0 to ensure compatibility.
We can install them at version 16.1.0 by pinning them to 16.1.0 when the packages are installed.