### PR TITLE
packages almalinux-8: pin Apache Arrow version

### DIFF
--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,6 +22,8 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
+    arrow-devel-16.1.0-1.el8.x86_64 \
+    arrow16-libs-16.1.0-1.el8.x86_64 \
     groonga-devel \
     llvm-toolset \
     llvm-devel \

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,10 +22,10 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
-    # Normally, both arrow-devel and arrow-libs are installed automatically as dependencies packages of groonga-devel.
-    # When installed this way, the latest version are used.
-    # However, we need to pin them to version 16.1.0 in this maintenance branch.
-    # Because we used 16.1.0 when PGroonga was 3.2.2 built.
+    # Normally, both arrow-devel and arrow-libs are installed automatically as dependency of groonga-devel.
+    # However, when installed this way, the latest version(24.0.0) is also installed even if we pin groonga-devel to 14.0.6.
+    # We want to restrict their versions to 16.1.0 to ensure compatibility.
+    # We can install them at version 16.1.0 by pinning them to 16.1.0 when the packages are installed.
     arrow-devel-16.1.0-1.el8.x86_64 \
     arrow16-libs-16.1.0-1.el8.x86_64 \
     groonga-devel \

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,6 +22,10 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
+    # Normally, both arrow-devel and arrow-libs are installed automatically as dependencies packages of groonga-devel.
+    # When installed this way, the latest version are used.
+    # However, we need to pin them to version 16.1.0 in this maintenance branch.
+    # Because we used 16.1.0 when PGroonga was 3.2.2 built.
     arrow-devel-16.1.0-1.el8.x86_64 \
     arrow16-libs-16.1.0-1.el8.x86_64 \
     groonga-devel \


### PR DESCRIPTION
Normally, both arrow-devel and arrow-libs are installed automatically as dependency of groonga-devel.
However, when installed this way, the latest version(24.0.0) is also installed even if we  pin groonga-devel to 14.0.6 as shown below:

```
# dnf install --enablerepo=powertools groonga-devel-14.0.6-1.el8.x86_64
Last metadata expiration check: 0:20:35 ago on Thu Jul  2 00:03:50 2026.
Dependencies resolved.
===========================================================================================================================================================================================================
 Package                                           Architecture                         Version                                                 Repository                                            Size
===========================================================================================================================================================================================================
Installing:
 groonga-devel                                     x86_64                               14.0.6-1.el8                                            groonga-almalinux                                     78 k
Installing dependencies:
 arrow-devel                                       x86_64                               24.0.0-1.el8                                            apache-arrow-almalinux                                14 M
 arrow16-libs                                      x86_64                               16.1.0-1.el8                                            apache-arrow-almalinux                               7.8 M
 arrow2400-libs                                    x86_64                               24.0.0-1.el8                                            apache-arrow-almalinux                               7.3 M
...
```

We want to restrict their versions to 16.1.0 to ensure compatibility.
We can install them at version 16.1.0 by pinning them to 16.1.0 when the packages are installed as shown below:

```
# dnf install --enablerepo=powertools groonga-devel-14.0.6-1.el8 arrow-devel-16.1.0-1.el8.x86_64 arrow16-libs-16.1.0-1.el8.x86_64
Last metadata expiration check: 0:24:11 ago on Thu Jul  2 00:03:50 2026.
Dependencies resolved.
===========================================================================================================================================================================================================
 Package                                            Architecture                          Version                                              Repository                                             Size
===========================================================================================================================================================================================================
Installing:
 arrow-devel                                        x86_64                                16.1.0-1.el8                                         apache-arrow-almalinux                                 18 M
 arrow16-libs                                       x86_64                                16.1.0-1.el8                                         apache-arrow-almalinux                                7.8 M
 groonga-devel                                      x86_64                                14.0.6-1.el8                                         groonga-almalinux                                      78 k
Installing dependencies:
 brotli-devel                                       x86_64                                1.0.6-4.el8_10                                       appstream                                              30 k
 bzip2-devel                                        x86_64                                1.0.6-28.el8_10                                      baseos                                                224 k
 cmake-filesystem                                   x86_64                                3.26.5-2.el8                                         appstream                                              44 k
 groonga-libs                                       x86_64                                14.0.6-1.el8                                         groonga-almalinux                                     2.7 M
 json-devel                                         x86_64                                3.6.1-2.el8                                          epel                                                  142 k
 keyutils-libs-devel                                x86_64                                1.5.10-9.el8                                         baseos                                                 47 k
 krb5-devel                                         x86_64                                1.18.2-34.el8_10                                     baseos                                                562 k
 libcom_err-devel                                   x86_64                                1.45.6-7.el8_10                                      baseos                                                 38 k
 libcurl-devel                                      x86_64                                7.61.1-34.el8_10.11                                  baseos                                                836 k
 libkadm5                                           x86_64                                1.18.2-34.el8_10                                     baseos                                                188 k
 libselinux-devel                                   x86_64                                2.9-11.el8_10                                        baseos                                                199 k
 libsepol-devel                                     x86_64                                2.9-3.el8                                            baseos                                                 86 k
 libverto-devel                                     x86_64                                0.3.2-2.el8                                          baseos                                                 17 k
 lz4                                                x86_64                                1.8.3-5.el8_10                                       baseos                                                103 k
 lz4-devel                                          x86_64                                1.8.3-5.el8_10                                       baseos                                                 31 k
 msgpack                                            x86_64                                3.1.0-3.el8                                          epel                                                   29 k
 msgpack-devel                                      x86_64                                3.1.0-3.el8                                          epel                                                  308 k
 openssl-devel                                      x86_64                                1:1.1.1k-16.el8_6                                    baseos                                                2.3 M
 pcre2-devel                                        x86_64                                10.32-3.el8_6                                        baseos                                                604 k
 pcre2-utf16                                        x86_64                                10.32-3.el8_6                                        baseos                                                228 k
 pcre2-utf32                                        x86_64                                10.32-3.el8_6                                        baseos                                                219 k
 re2                                                x86_64                                20190801-17.el8                                      epel                                                  190 k
 re2-devel                                          x86_64                                20190801-17.el8                                      epel                                                   33 k
 snappy                                             x86_64                                1.1.8-3.el8                                          baseos                                                 37 k
 snappy-devel                                       x86_64                                1.1.8-3.el8                                          powertools                                             25 k
 xxhash-libs                                        x86_64                                0.8.2-1.el8                                          appstream                                              37 k

Transaction Summary
===========================================================================================================================================================================================================
Install  29 Packages
```