### PR TITLE
packages almalinux-8: pin groonga-devel package version

### DIFF
--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
-    groonga-devel-14.0.6-1.el8.x86_64
+    groonga-devel-14.0.6-1.el8.x86_64 \
     llvm-toolset \
     llvm-devel \
     msgpack-devel \

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,6 +22,9 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
+    # If we do not pin the version of groonga-devel, groonga-devel uses the latest available version(16.0.5).
+    # However, this branch uses PGroonga version 3.2.2, which was built with Groonga 14.0.6.
+    # Therefore, we pin groonga-devel to 14.0.6 to ensure compatibility.
     groonga-devel-14.0.6-1.el8.x86_64 \
     llvm-toolset \
     llvm-devel \

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install --enablerepo=powertools -y ${quiet} \
     ccache \
-    groonga-devel \
+    groonga-devel-14.0.6-1.el8.x86_64
     llvm-toolset \
     llvm-devel \
     msgpack-devel \


### PR DESCRIPTION
If we do not pin the version of groonga-devel, groonga-devel uses the latest available version(16.0.5) as shown below:

```
# dnf install --enablerepo=powertools groonga-devel
Last metadata expiration check: 0:10:25 ago on Thu Jul  2 00:03:50 2026.
Dependencies resolved.
===========================================================================================================================================================================================================
 Package                                              Architecture                         Version                                              Repository                                            Size
===========================================================================================================================================================================================================
Installing:
 groonga-devel                                        x86_64                               16.0.5-1.el8                                         groonga-almalinux                                    107 k
Installing dependencies:
 arrow-compute-devel                                  x86_64                               24.0.0-1.el8                                         apache-arrow-almalinux                               3.4 M
 arrow-devel                                          x86_64                               24.0.0-1.el8                                         apache-arrow-almalinux                                14 M
 arrow2400-compute-libs                               x86_64                               24.0.0-1.el8                                         apache-arrow-almalinux                               3.0 M
 arrow2400-libs                                       x86_64                               24.0.0-1.el8                                         apache-arrow-almalinux                               7.3 M
 brotli-devel                                         x86_64                               1.0.6-4.el8_10                                       appstream                                             30 k
 bzip2-devel                                          x86_64                               1.0.6-28.el8_10                                      baseos                                               224 k
 cmake-filesystem                                     x86_64                               3.26.5-2.el8                                         appstream                                             44 k
 groonga-libs                                         x86_64                               16.0.5-1.el8                                         groonga-almalinux                                    5.1 M
 keyutils-libs-devel                                  x86_64                               1.5.10-9.el8                                         baseos                                                47 k
 krb5-devel                                           x86_64                               1.18.2-34.el8_10                                     baseos                                               562 k
 libatomic                                            x86_64                               8.5.0-28.el8_10.alma.1                               baseos                                                25 k
 libcom_err-devel                                     x86_64                               1.45.6-7.el8_10                                      baseos                                                38 k
 libcurl-devel                                        x86_64                               7.61.1-34.el8_10.11                                  baseos                                               836 k
 libkadm5                                             x86_64                               1.18.2-34.el8_10                                     baseos                                               188 k
 libselinux-devel                                     x86_64                               2.9-11.el8_10                                        baseos                                               199 k
 libsepol-devel                                       x86_64                               2.9-3.el8                                            baseos                                                86 k
 libverto-devel                                       x86_64                               0.3.2-2.el8                                          baseos                                                17 k
 lz4                                                  x86_64                               1.8.3-5.el8_10                                       baseos                                               103 k
 lz4-devel                                            x86_64                               1.8.3-5.el8_10                                       baseos                                                31 k
 msgpack                                              x86_64                               3.1.0-3.el8                                          epel                                                  29 k
 msgpack-devel                                        x86_64                               3.1.0-3.el8                                          epel                                                 308 k
 openssl-devel                                        x86_64                               1:1.1.1k-16.el8_6                                    baseos                                               2.3 M
 pcre2-devel                                          x86_64                               10.32-3.el8_6                                        baseos                                               604 k
 pcre2-utf16                                          x86_64                               10.32-3.el8_6                                        baseos                                               228 k
 pcre2-utf32                                          x86_64                               10.32-3.el8_6                                        baseos                                               219 k
 re2                                                  x86_64                               20190801-17.el8                                      epel                                                 190 k
 re2-devel                                            x86_64                               20190801-17.el8                                      epel                                                  33 k
 simdjson                                             x86_64                               3.6.3-1.el8                                          epel                                                  93 k
 snappy                                               x86_64                               1.1.8-3.el8                                          baseos                                                37 k
 snappy-devel                                         x86_64                               1.1.8-3.el8                                          powertools                                            25 k
 xxhash-libs                                          x86_64                               0.8.2-1.el8                                          appstream                                             37 k

Transaction Summary
===========================================================================================================================================================================================================
Install  32 Packages
```

However, this branch uses PGroonga version 3.2.2, which was built with Groonga 14.0.6.
Therefore, we pin groonga-devel to 14.0.6 to ensure compatibility.
