### PR TITLE
packages almalinux-8: pin PostgreSQL version

### DIFF
--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -26,6 +26,9 @@ RUN \
     llvm-toolset \
     llvm-devel \
     msgpack-devel \
+    # If we do not pin the version of PostgreSQL, PostgreSQL uses the latest available version(12.22).
+    # However, this branch uses PGroonga version 3.2.2, which was built with PostgreSQL 12.21.
+    # Therefore, we pin PostgreSQL to 12.21 to ensure compatibility.
     postgresql12-devel-12.21-1PGDG.rhel8.x86_64 \
     xxhash-devel && \
   dnf clean -y ${quiet} all

--- a/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
+++ b/packages/postgresql-12-pgdg-pgroonga/yum/almalinux-8/Dockerfile
@@ -26,6 +26,6 @@ RUN \
     llvm-toolset \
     llvm-devel \
     msgpack-devel \
-    postgresql12-devel \
+    postgresql12-devel-12.21-1PGDG.rhel8.x86_64 \
     xxhash-devel && \
   dnf clean -y ${quiet} all


### PR DESCRIPTION
If we do not pin the version of PostgreSQL, PostgreSQL uses the latest available version(12.22) as below:

```
# dnf install --enablerepo=powertools postgresql12-devel
AlmaLinux 8 - PowerTools                                                                                                                                                   1.5 MB/s | 6.2 MB     00:04    
Last metadata expiration check: 0:00:02 ago on Thu Jul  2 00:03:50 2026.
Dependencies resolved.
===========================================================================================================================================================================================================
 Package                                              Architecture                             Version                                              Repository                                        Size
===========================================================================================================================================================================================================
Installing:
 postgresql12-devel                                   x86_64                                   12.22-1PGDG.rhel8                                    pgdg12-archive                                   2.3 M
Installing dependencies:
 libicu-devel                                         x86_64                                   60.3-2.el8_1                                         baseos                                           922 k
 perl-IO-Tty                                          x86_64                                   1.12-11.el8                                          powertools                                        48 k
 perl-IPC-Run                                         noarch                                   0.99-1.el8                                           powertools                                       129 k
 perl-Test-Simple                                     noarch                                   1:1.302135-1.el8                                     appstream                                        516 k
 perl-Time-HiRes                                      x86_64                                   4:1.9758-2.el8                                       appstream                                         60 k
 postgresql12                                         x86_64                                   12.22-1PGDG.rhel8                                    pgdg12-archive                                   1.7 M
 postgresql12-libs                                    x86_64                                   12.22-1PGDG.rhel8                                    pgdg12-archive                                   408 k

Transaction Summary
===========================================================================================================================================================================================================
Install  8 Packages
```

However, this branch uses PGroonga version 3.2.2, which was built with PostgreSQL 12.21.
Therefore, we pin PostgreSQL to 12.21 to ensure compatibility.
