### PR TITLE
pgroonga: emmbedding release number into initialize log

### DIFF
--- a/makefiles/pgrn-pgxs.mk
+++ b/makefiles/pgrn-pgxs.mk
@@ -6,10 +6,12 @@ PGRN_VERSION =						\
 	$(shell grep default_version pgroonga.control |	\
 		sed -e "s/^.*'\([0-9.]*\)'$$/\1/")
 
+PGRN_VERSION_RELEASE = 2
 PG_CPPFLAGS += $(shell pkg-config --cflags $(PACKAGES))
 SHLIB_LINK += $(shell pkg-config --libs $(PACKAGES)) -lm
 
 PG_CPPFLAGS += -DPGRN_VERSION="\"${PGRN_VERSION}\""
+PG_CPPFLAGS += -DPGRN_VERSION_RELEASE="\"${PGRN_VERSION_RELEASE}\""
 ifdef PGRN_DEBUG
 PG_CPPFLAGS += -O0 -g3 -DPGROONGA_DEBUG=1
 ifeq ($(uname), Linux)

--- a/src/pgroonga.c
+++ b/src/pgroonga.c
@@ -717,8 +717,11 @@ _PG_init(void)
 
 		PGrnGroongaInitialized = true;
 
-		GRN_LOG(
-			ctx, GRN_LOG_NOTICE, "pgroonga: initialize: <%s>", PGRN_VERSION);
+		GRN_LOG(ctx,
+				GRN_LOG_NOTICE,
+				"pgroonga: initialize: <%s-%s>",
+				PGRN_VERSION,
+				PGRN_VERSION_RELEASE);
 
 		GRN_TEXT_INIT(&PGrnInspectBuffer, 0);
 


### PR DESCRIPTION
Display release number in init log for version distinction as shown below:

```
2026-07-02 05:45:58.308849|n|13257: pgroonga: initialize: <3.2.2-2>
```

We are keeping `default_version` unchanged without Upgrade SQL.