### PR TITLE
ci: fix workflow not running in tag pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "copilot/**"
+    tags:
+      - "*"
   pull_request:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "copilot/**"
+    tags:
+      - "*"
   pull_request:
   schedule:
     # * UTC 16:30

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "copilot/**"
+    tags:
+      - "*"
   pull_request:
   schedule:
     - cron: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "copilot/**"
+    tags:
+      - "*"
   pull_request:
   schedule:
     - cron: |

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "copilot/**"
+    tags:
+      - "*"
   pull_request:
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches-ignore:
       - "copilot/**"
+    tags:
+      - "*"
   pull_request:
   schedule:
     - cron: |


### PR DESCRIPTION
After the GH-950 changes, specifying "branches-ignore" prevented the workflow from running on tag pushes unless "tags" was also specified.