### PR TITLE
packages ubuntu: add missing target OS version definition

### DIFF
--- a/packages/postgresql-18-pgroonga/Rakefile
+++ b/packages/postgresql-18-pgroonga/Rakefile
@@ -9,7 +9,7 @@ class PostgreSQL18PGroongaPackageTask < VersionedPGroongaPackageTask
     []
   end
 
-  def enable_ubuntu?
+  def ubuntu_targets_default
     [
       ["resolute", "26.04"],
     ]


### PR DESCRIPTION
If "ubuntu_target_default" is not defined, "ubuntu_targets_default" in /groonga/packages/launchpad-helper.rb is used.

Groonga's "ubuntu_targets_default" as jammy, noble, and resolute. However, jammy and noble do not provide the PostgreSQL 18 packages in the official Ubuntu repositories.

Therefore, we should override ubuntu_targets_default.
