### PR TITLE
physical-table-names: implement logic to get the logical index oid

### DIFF
--- a/data/pgroonga--4.0.8--4.0.9.sql
+++ b/data/pgroonga--4.0.8--4.0.9.sql
@@ -1,6 +1,6 @@
 -- Upgrade SQL
 
-CREATE OR REPLACE FUNCTION pgroonga_physical_table_names(logical_table_index text, argument_prefix text)
+CREATE OR REPLACE FUNCTION pgroonga_physical_table_names(logical_index_name text, argument_prefix text)
 	RETURNS text[]
 	AS 'MODULE_PATHNAME', 'pgroonga_physical_table_names'
 	LANGUAGE C

--- a/data/pgroonga--4.0.8--4.0.9.sql
+++ b/data/pgroonga--4.0.8--4.0.9.sql
@@ -1,6 +1,6 @@
 -- Upgrade SQL
 
-CREATE OR REPLACE FUNCTION pgroonga_physical_table_names(logical_table_name text, argument_prefix text)
+CREATE OR REPLACE FUNCTION pgroonga_physical_table_names(logical_table_index text, argument_prefix text)
 	RETURNS text[]
 	AS 'MODULE_PATHNAME', 'pgroonga_physical_table_names'
 	LANGUAGE C

--- a/data/pgroonga--4.0.9--4.0.8.sql
+++ b/data/pgroonga--4.0.9--4.0.8.sql
@@ -1,3 +1,3 @@
 -- Downgrade SQL
 
-DROP FUNCTION IF EXISTS pgroonga_physical_table_names;
+DROP FUNCTION IF EXISTS pgroonga_physical_table_names(logical_table_index text, argument_prefix text);

--- a/data/pgroonga--4.0.9--4.0.8.sql
+++ b/data/pgroonga--4.0.9--4.0.8.sql
@@ -1,3 +1,3 @@
 -- Downgrade SQL
 
-DROP FUNCTION IF EXISTS pgroonga_physical_table_names(logical_table_index text, argument_prefix text);
+DROP FUNCTION IF EXISTS pgroonga_physical_table_names(logical_index_name text, argument_prefix text);

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -466,7 +466,7 @@ CREATE FUNCTION pgroonga_language_model_vectorize(model_name cstring, target tex
 	STRICT
 	PARALLEL SAFE;
 
-CREATE FUNCTION pgroonga_physical_table_names(logical_table_name text, argument_prefix text)
+CREATE FUNCTION pgroonga_physical_table_names(logical_table_index text, argument_prefix text)
 	RETURNS text[]
 	AS 'MODULE_PATHNAME', 'pgroonga_physical_table_names'
 	LANGUAGE C

--- a/data/pgroonga.sql
+++ b/data/pgroonga.sql
@@ -466,7 +466,7 @@ CREATE FUNCTION pgroonga_language_model_vectorize(model_name cstring, target tex
 	STRICT
 	PARALLEL SAFE;
 
-CREATE FUNCTION pgroonga_physical_table_names(logical_table_index text, argument_prefix text)
+CREATE FUNCTION pgroonga_physical_table_names(logical_index_name text, argument_prefix text)
 	RETURNS text[]
 	AS 'MODULE_PATHNAME', 'pgroonga_physical_table_names'
 	LANGUAGE C

--- a/expected/function/physical-table-names/nonexistent.out
+++ b/expected/function/physical-table-names/nonexistent.out
@@ -1,0 +1,8 @@
+CREATE TABLE blogs (
+  title text
+);
+CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
+SELECT pgroonga_physical_table_names('nonexistent',
+                                     'shard') AS physical_tables;
+ERROR:  relation "nonexistent" does not exist
+DROP TABLE blogs;

--- a/expected/function/physical-table-names/nonpartition.out
+++ b/expected/function/physical-table-names/nonpartition.out
@@ -5,5 +5,4 @@ CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
 SELECT pgroonga_physical_table_names('pgroonga_title_index',
                                      'shard') AS physical_tables;
 ERROR:  pgroonga: [physical-table-names] the specified index is not partitioned: <pgroonga_title_index>
-
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/nonpartition.out
+++ b/expected/function/physical-table-names/nonpartition.out
@@ -4,5 +4,6 @@ CREATE TABLE blogs (
 CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
 SELECT pgroonga_physical_table_names('pgroonga_title_index',
                                      'shard') AS physical_tables;
-ERROR:  pgroonga: [pyhsical-table-names] the specified index is not partitioned: <pgroonga_title_index>
+ERROR:  pgroonga: [physical-table-names] the specified index is not partitioned: <pgroonga_title_index>
+
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/nonpartition.out
+++ b/expected/function/physical-table-names/nonpartition.out
@@ -4,5 +4,5 @@ CREATE TABLE blogs (
 CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
 SELECT pgroonga_physical_table_names('pgroonga_title_index',
                                      'shard') AS physical_tables;
-ERROR:  pgroonga: [pyhsical-table-names] the specified index is not partitioned index: <pgroonga_title_index>
+ERROR:  pgroonga: [pyhsical-table-names] the specified index is not partitioned: <pgroonga_title_index>
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/nonpartition.out
+++ b/expected/function/physical-table-names/nonpartition.out
@@ -1,0 +1,8 @@
+CREATE TABLE blogs (
+  title text
+);
+CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
+SELECT pgroonga_physical_table_names('pgroonga_title_index',
+                                     'shard') AS physical_tables;
+ERROR:  pgroonga: [pyhsical-table-names] the specified index is not partitioned index: <pgroonga_title_index>
+DROP TABLE blogs;

--- a/sql/function/physical-table-names/nonexistent.sql
+++ b/sql/function/physical-table-names/nonexistent.sql
@@ -1,0 +1,9 @@
+CREATE TABLE blogs (
+  title text
+);
+CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
+
+SELECT pgroonga_physical_table_names('nonexistent',
+                                     'shard') AS physical_tables;
+
+DROP TABLE blogs;

--- a/sql/function/physical-table-names/nonpartition.sql
+++ b/sql/function/physical-table-names/nonpartition.sql
@@ -1,0 +1,9 @@
+CREATE TABLE blogs (
+  title text
+);
+CREATE INDEX pgroonga_title_index ON blogs USING pgroonga (title);
+
+SELECT pgroonga_physical_table_names('pgroonga_title_index',
+                                     'shard') AS physical_tables;
+
+DROP TABLE blogs;

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -1,6 +1,7 @@
 #include "pgroonga.h"
 
 #include "pgrn-groonga.h"
+#include "pgrn-pg.h"
 #include "pgrn-physical-table-names.h"
 
 #include <utils/builtins.h>
@@ -28,17 +29,8 @@ PGrnRelationIsPartitionedIndex(Relation relation)
 static Oid
 PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
 {
-	Datum logical_index_oid_datum = DirectFunctionCall1(
-		regclassin, CStringGetDatum(text_to_cstring(logical_index_name_text)));
-	if (!OidIsValid(logical_index_oid_datum))
-	{
-		PGrnCheckRC(GRN_INVALID_ARGUMENT,
-					"%s nonexistent index name: <%s>",
-					tag,
-					text_to_cstring(logical_index_name_text));
-	}
-
-	Oid logical_index_oid = DatumGetObjectId(logical_index_oid_datum);
+	Oid logical_index_oid =
+		PGrnPGIndexNameToID(text_to_cstring(logical_index_name_text));
 	Relation logical_index = RelationIdGetRelation(logical_index_oid);
 	if (!PGrnRelationIsPartitionedIndex(logical_index))
 	{

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -52,7 +52,7 @@ PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
 Datum
 pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 {
-	const char *tag = "[pyhsical-table-names]";
+	const char *tag = "[physical-table-names]";
 	text *logical_index_name_text = PG_GETARG_TEXT_PP(0);
 
 	PGrnGetLogicalIndexOid(tag, logical_index_name_text);

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -1,6 +1,9 @@
 #include "pgroonga.h"
 
+#include "pgrn-groonga.h"
 #include "pgrn-physical-table-names.h"
+
+#include <utils/builtins.h>
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_physical_table_names);
 
@@ -16,6 +19,40 @@ PGrnFinalizePhysicalTableNames(void)
 	;
 }
 
+static bool
+PGrnRelationIsPartitionedIndex(Relation relation)
+{
+	return PGRN_RELKIND_HAS_PARTITIONS(RelationGetForm(relation)->relkind);
+}
+
+static Oid
+PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
+{
+	Datum logical_index_oid_datum = DirectFunctionCall1(
+		regclassin, CStringGetDatum(text_to_cstring(logical_index_name_text)));
+	if (!OidIsValid(logical_index_oid_datum))
+	{
+		PGrnCheckRC(GRN_INVALID_ARGUMENT,
+					"%s nonexistent index name: <%s>",
+					tag,
+					text_to_cstring(logical_index_name_text));
+	}
+
+	Oid logical_index_oid = DatumGetObjectId(logical_index_oid_datum);
+	Relation logical_index = RelationIdGetRelation(logical_index_oid);
+	if (!PGrnRelationIsPartitionedIndex(logical_index))
+	{
+		RelationClose(logical_index);
+		PGrnCheckRC(GRN_INVALID_ARGUMENT,
+					"%s the specified index is not partitioned index: <%s>",
+					tag,
+					text_to_cstring(logical_index_name_text));
+	}
+	RelationClose(logical_index);
+
+	return logical_index_oid;
+}
+
 /**
  * pgroonga_physical_table_names(logical_table_name text, argument_prefix text)
  * : text[]
@@ -23,5 +60,9 @@ PGrnFinalizePhysicalTableNames(void)
 Datum
 pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 {
+	const char *tag = "[pyhsical-table-names]";
+	text *logical_index_name_text = PG_GETARG_TEXT_PP(0);
+
+	PGrnGetLogicalIndexOid(tag, logical_index_name_text);
 	PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));
 }

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -31,7 +31,7 @@ PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
 {
 	Oid logical_index_oid =
 		PGrnPGIndexNameToID(text_to_cstring(logical_index_name_text));
-	Relation logical_index = RelationIdGetRelation(logical_index_oid);
+	Relation logical_index = PGrnPGResolveIndexID(logical_index_oid);
 	if (!PGrnRelationIsPartitionedIndex(logical_index))
 	{
 		RelationClose(logical_index);

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -36,7 +36,7 @@ PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
 	{
 		RelationClose(logical_index);
 		PGrnCheckRC(GRN_INVALID_ARGUMENT,
-					"%s the specified index is not partitioned index: <%s>",
+					"%s the specified index is not partitioned: <%s>",
 					tag,
 					text_to_cstring(logical_index_name_text));
 	}

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -23,7 +23,7 @@ PGrnFinalizePhysicalTableNames(void)
 static bool
 PGrnRelationIsPartitionedIndex(Relation relation)
 {
-	return PGRN_RELKIND_HAS_PARTITIONS(RelationGetForm(relation)->relkind);
+	return RelationGetForm(relation)->relkind == RELKIND_PARTITIONED_INDEX;
 }
 
 static Oid

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -46,7 +46,7 @@ PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
 }
 
 /**
- * pgroonga_physical_table_names(logical_table_name text, argument_prefix text)
+ * pgroonga_physical_table_names(logical_index_name text, argument_prefix text)
  * : text[]
  */
 Datum


### PR DESCRIPTION
This oid is used to retrieve the physical index oids.
The physical index oids are used to retrieve source table names.

In a follow-up change, I will implement the functionality to retrieve the physical index OIDs and source table names.