### PR TITLE
physical-table-names: implement for getting physical table names

### DIFF
--- a/expected/function/physical-table-names/nonchildren.out
+++ b/expected/function/physical-table-names/nonchildren.out
@@ -1,0 +1,14 @@
+CREATE TABLE blogs (
+  title text,
+  content text,
+  registered_at date
+) PARTITION BY RANGE (registered_at);
+CREATE INDEX pgroonga_content_index ON blogs USING pgroonga (content);
+SELECT pgroonga_physical_table_names('pgroonga_content_index',
+                                     'shard') AS physical_tables;
+ physical_tables 
+-----------------
+ {}
+(1 row)
+
+DROP TABLE blogs;

--- a/expected/function/physical-table-names/range-partition.out
+++ b/expected/function/physical-table-names/range-partition.out
@@ -18,15 +18,16 @@ VALUES
 ('Hello 2025!!!', 'Wishing you a happy New Year', '2025-01-01 08:39:00'),
 ('Hello PGroonga', 'PGroonga is a PostgreSQL extension to use Groonga as the index', '2025-12-25 16:47:00');
 CREATE INDEX pgroonga_content_index ON blogs USING pgroonga (content);
-SELECT regexp_replace(
-  pgroonga_physical_table_names('pgroonga_content_index',
-                                'shard')::text,
-  'Sources[0-9]+',
-  'Sources<OID>',
-  'g') AS physical_tables;
-             physical_tables              
-------------------------------------------
- {Sources<OID>,Sources<OID>,Sources<OID>}
+SELECT pgroonga_physical_table_names('pgroonga_content_index', 'shard') = ARRAY(
+  SELECT 'Sources' || pg_class.oid::text
+    FROM pg_class
+   WHERE pg_class.oid IN('blogs_2023_content_idx'::regclass,
+                         'blogs_2024_content_idx'::regclass,
+                         'blogs_2025_content_idx'::regclass)
+ORDER BY pg_class.oid);
+ ?column? 
+----------
+ t
 (1 row)
 
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/range-partition.out
+++ b/expected/function/physical-table-names/range-partition.out
@@ -26,7 +26,7 @@ SELECT regexp_replace(
   'g') AS physical_tables;
  physical_tables 
 -----------------
- }'Sources<OID>', 'Sources<OID>', 'Sources<OID>'}
+ {'Sources<OID>', 'Sources<OID>', 'Sources<OID>'}
 (1 row)
 
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/range-partition.out
+++ b/expected/function/physical-table-names/range-partition.out
@@ -24,9 +24,9 @@ SELECT regexp_replace(
   'Sources[0-9]+',
   'Sources<OID>',
   'g') AS physical_tables;
- physical_tables 
------------------
- {'Sources<OID>', 'Sources<OID>', 'Sources<OID>'}
+             physical_tables              
+------------------------------------------
+ {Sources<OID>,Sources<OID>,Sources<OID>}
 (1 row)
 
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/range-partition.out
+++ b/expected/function/physical-table-names/range-partition.out
@@ -26,7 +26,7 @@ SELECT regexp_replace(
   'g') AS physical_tables;
  physical_tables 
 -----------------
- {}
+ }'Sources<OID>', 'Sources<OID>', 'Sources<OID>'}
 (1 row)
 
 DROP TABLE blogs;

--- a/expected/function/physical-table-names/range-partition.out
+++ b/expected/function/physical-table-names/range-partition.out
@@ -19,7 +19,7 @@ VALUES
 ('Hello PGroonga', 'PGroonga is a PostgreSQL extension to use Groonga as the index', '2025-12-25 16:47:00');
 CREATE INDEX pgroonga_content_index ON blogs USING pgroonga (content);
 SELECT pgroonga_physical_table_names('pgroonga_content_index', 'shard') = ARRAY(
-  SELECT 'Sources' || pg_class.oid::text
+  SELECT 'Sources' || pg_class.relfilenode::text
     FROM pg_class
    WHERE pg_class.oid IN('blogs_2023_content_idx'::regclass,
                          'blogs_2024_content_idx'::regclass,

--- a/sql/function/physical-table-names/nonchildren.sql
+++ b/sql/function/physical-table-names/nonchildren.sql
@@ -1,0 +1,12 @@
+CREATE TABLE blogs (
+  title text,
+  content text,
+  registered_at date
+) PARTITION BY RANGE (registered_at);
+
+CREATE INDEX pgroonga_content_index ON blogs USING pgroonga (content);
+
+SELECT pgroonga_physical_table_names('pgroonga_content_index',
+                                     'shard') AS physical_tables;
+
+DROP TABLE blogs;

--- a/sql/function/physical-table-names/range-partition.sql
+++ b/sql/function/physical-table-names/range-partition.sql
@@ -23,7 +23,7 @@ VALUES
 CREATE INDEX pgroonga_content_index ON blogs USING pgroonga (content);
 
 SELECT pgroonga_physical_table_names('pgroonga_content_index', 'shard') = ARRAY(
-  SELECT 'Sources' || pg_class.oid::text
+  SELECT 'Sources' || pg_class.relfilenode::text
     FROM pg_class
    WHERE pg_class.oid IN('blogs_2023_content_idx'::regclass,
                          'blogs_2024_content_idx'::regclass,

--- a/sql/function/physical-table-names/range-partition.sql
+++ b/sql/function/physical-table-names/range-partition.sql
@@ -22,11 +22,12 @@ VALUES
 
 CREATE INDEX pgroonga_content_index ON blogs USING pgroonga (content);
 
-SELECT regexp_replace(
-  pgroonga_physical_table_names('pgroonga_content_index',
-                                'shard')::text,
-  'Sources[0-9]+',
-  'Sources<OID>',
-  'g') AS physical_tables;
+SELECT pgroonga_physical_table_names('pgroonga_content_index', 'shard') = ARRAY(
+  SELECT 'Sources' || pg_class.oid::text
+    FROM pg_class
+   WHERE pg_class.oid IN('blogs_2023_content_idx'::regclass,
+                         'blogs_2024_content_idx'::regclass,
+                         'blogs_2025_content_idx'::regclass)
+ORDER BY pg_class.oid);
 
 DROP TABLE blogs;

--- a/src/pgrn-groonga.c
+++ b/src/pgrn-groonga.c
@@ -143,15 +143,22 @@ PGrnLookupIndexColumn(Relation index, unsigned int nthAttribute, int errorLevel)
 }
 
 void
+PGrnGetSourcesTableNameFromOid(Oid oid, char tableName[GRN_TABLE_MAX_KEY_SIZE])
+{
+	Oid fileNodeID = PGrnPGIndexIDToFileNodeID(oid);
+	snprintf(tableName,
+			 GRN_TABLE_MAX_KEY_SIZE,
+			 PGrnSourcesTableNameFormat,
+			 fileNodeID);
+}
+
+void
 PGrnFormatSourcesTableName(const char *indexName,
 						   char output[GRN_TABLE_MAX_KEY_SIZE])
 {
 	Oid indexID;
-	Oid fileNodeID;
 	indexID = PGrnPGIndexNameToID(indexName);
-	fileNodeID = PGrnPGIndexIDToFileNodeID(indexID);
-	snprintf(
-		output, GRN_TABLE_MAX_KEY_SIZE, PGrnSourcesTableNameFormat, fileNodeID);
+	PGrnGetSourcesTableNameFromOid(indexID, output);
 }
 
 grn_obj *

--- a/src/pgrn-groonga.h
+++ b/src/pgrn-groonga.h
@@ -167,7 +167,8 @@ PGrnLookupLexicon(Relation index, unsigned int nthAttribute, int errorLevel);
 grn_obj *PGrnLookupIndexColumn(Relation index,
 							   unsigned int nthAttribute,
 							   int errorLevel);
-
+void PGrnGetSourcesTableNameFromOid(Oid oid,
+									char tableName[GRN_TABLE_MAX_KEY_SIZE]);
 void PGrnFormatSourcesTableName(const char *indexName,
 								char output[GRN_TABLE_MAX_KEY_SIZE]);
 

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -30,22 +30,22 @@ PGrnRelationIsPartitionedIndex(Relation relation)
 }
 
 static Oid
-PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
+PGrnGetLogicalIndexOid(const char *tag, text *logicalIndexNameText)
 {
-	Oid logical_index_oid =
-		PGrnPGIndexNameToID(text_to_cstring(logical_index_name_text));
-	Relation logical_index = PGrnPGResolveIndexID(logical_index_oid);
-	if (!PGrnRelationIsPartitionedIndex(logical_index))
+	Oid logicalIndexOid =
+		PGrnPGIndexNameToID(text_to_cstring(logicalIndexNameText));
+	Relation logicalIndex = PGrnPGResolveIndexID(logicalIndexOid);
+	if (!PGrnRelationIsPartitionedIndex(logicalIndex))
 	{
-		RelationClose(logical_index);
+		RelationClose(logicalIndex);
 		PGrnCheckRC(GRN_INVALID_ARGUMENT,
 					"%s the specified index is not partitioned: <%s>",
 					tag,
-					text_to_cstring(logical_index_name_text));
+					text_to_cstring(logicalIndexNameText));
 	}
-	RelationClose(logical_index);
+	RelationClose(logicalIndex);
 
-	return logical_index_oid;
+	return logicalIndexOid;
 }
 
 static void
@@ -66,12 +66,11 @@ Datum
 pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 {
 	const char *tag = "[physical-table-names]";
-	text *logical_index_name_text = PG_GETARG_TEXT_PP(0);
+	text *logicalIndexNameText = PG_GETARG_TEXT_PP(0);
 
-	Oid logical_index_oid =
-		PGrnGetLogicalIndexOid(tag, logical_index_name_text);
+	Oid logicalIndexOid = PGrnGetLogicalIndexOid(tag, logicalIndexNameText);
 
-	LockRelationOid(logical_index_oid, AccessShareLock);
+	LockRelationOid(logicalIndexOid, AccessShareLock);
 	/**
 	 * find_inheritance_children() here acquires an AccessShareLock and holds it
 	 * until the end of the transaction. Therefore, the following operations on
@@ -85,52 +84,51 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 	 * - ALTER INDEX
 	 * - ALTER TABLE
 	 */
-	List *physical_index_oids =
-		find_inheritance_children(logical_index_oid, AccessShareLock);
-	if (!physical_index_oids)
+	List *physicalIndexOids =
+		find_inheritance_children(logicalIndexOid, AccessShareLock);
+	if (!physicalIndexOids)
 	{
-		UnlockRelationOid(logical_index_oid, AccessShareLock);
+		UnlockRelationOid(logicalIndexOid, AccessShareLock);
 		GRN_LOG(ctx,
 				GRN_LOG_WARNING,
 				"%s <%s> has not children",
 				tag,
-				text_to_cstring(logical_index_name_text));
+				text_to_cstring(logicalIndexNameText));
 		PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));
 	}
 	ListCell *cell;
 
-	Oid physical_index_oid;
-	List *physical_table_names = NIL;
-	char table_name_buffer[GRN_TABLE_MAX_KEY_SIZE];
-	foreach (cell, physical_index_oids)
+	Oid physicalIndexOid;
+	List *physicalTableNames = NIL;
+	char tableNameBuffer[GRN_TABLE_MAX_KEY_SIZE];
+	foreach (cell, physicalIndexOids)
 	{
-		physical_index_oid = lfirst_oid(cell);
-		if (logical_index_oid == physical_index_oid)
+		physicalIndexOid = lfirst_oid(cell);
+		if (logicalIndexOid == physicalIndexOid)
 		{
 			/**
 			 * find_inheritance_children() returns contain parent index oid.
-			 * Therefore, the first element of physical_index_oids skip.
+			 * Therefore, the first element of physicalIndexOids skip.
 			 */
 			continue;
 		}
-		PGrnGetSourcesTableNameFromOid(physical_index_oid, table_name_buffer);
-		physical_table_names =
-			lappend(physical_table_names,
-					(void *) (cstring_to_text(table_name_buffer)));
+		PGrnGetSourcesTableNameFromOid(physicalIndexOid, tableNameBuffer);
+		physicalTableNames = lappend(
+			physicalTableNames, (void *) (cstring_to_text(tableNameBuffer)));
 	}
-	UnlockRelationOid(logical_index_oid, AccessShareLock);
+	UnlockRelationOid(logicalIndexOid, AccessShareLock);
 
-	unsigned int n_elements = list_length(physical_table_names);
-	Datum *physical_table_names_datum = palloc(n_elements * sizeof(Datum));
+	unsigned int nElements = list_length(physicalTableNames);
+	Datum *physicalTableNamesDatum = palloc(nElements * sizeof(Datum));
 	unsigned int i = 0;
-	foreach (cell, physical_table_names)
+	foreach (cell, physicalTableNames)
 	{
-		physical_table_names_datum[i++] = (Datum) lfirst(cell);
+		physicalTableNamesDatum[i++] = (Datum) lfirst(cell);
 	}
 
-	int dims[1] = {n_elements};
+	int dims[1] = {nElements};
 	int lbs[1] = {1};
-	PG_RETURN_ARRAYTYPE_P(construct_md_array(physical_table_names_datum,
+	PG_RETURN_ARRAYTYPE_P(construct_md_array(physicalTableNamesDatum,
 											 NULL,
 											 1,
 											 dims,

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -64,6 +64,16 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 	LockRelationOid(logical_index_oid, AccessShareLock);
 	List *physical_index_oids =
 		find_inheritance_children(logical_index_oid, AccessShareLock);
+	if (!physical_index_oids)
+	{
+		UnlockRelationOid(logical_index_oid, AccessShareLock);
+		GRN_LOG(ctx,
+				GRN_LOG_WARNING,
+				"%s <%s> has not children",
+				tag,
+				text_to_cstring(logical_index_name_text));
+		PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));
+	}
 	ListCell *cell;
 	Oid physical_index_oid;
 	List *physical_table_names = NIL;

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -48,6 +48,16 @@ PGrnGetLogicalIndexOid(const char *tag, text *logical_index_name_text)
 	return logical_index_oid;
 }
 
+static void
+PGrnGetSourcesTableNameFromOid(Oid oid, char tableName[GRN_TABLE_MAX_KEY_SIZE])
+{
+	Oid fileNodeID = PGrnPGIndexIDToFileNodeID(oid);
+	snprintf(tableName,
+			 GRN_TABLE_MAX_KEY_SIZE,
+			 PGrnSourcesTableNameFormat,
+			 fileNodeID);
+}
+
 /**
  * pgroonga_physical_table_names(logical_index_name text, argument_prefix text)
  * : text[]
@@ -75,9 +85,9 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 		PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));
 	}
 	ListCell *cell;
+
 	Oid physical_index_oid;
 	List *physical_table_names = NIL;
-	char *physical_index_name;
 	char table_name_buffer[GRN_TABLE_MAX_KEY_SIZE];
 	foreach (cell, physical_index_oids)
 	{
@@ -90,8 +100,7 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 			 */
 			continue;
 		}
-		physical_index_name = get_rel_name(physical_index_oid);
-		PGrnFormatSourcesTableName(physical_index_name, table_name_buffer);
+		PGrnGetSourcesTableNameFromOid(physical_index_oid, table_name_buffer);
 		physical_table_names =
 			lappend(physical_table_names,
 					(void *) (cstring_to_text(table_name_buffer)));

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -97,7 +97,8 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 	{
 		physicalIndexOid = lfirst_oid(cell);
 		PGrnGetSourcesTableNameFromOid(physicalIndexOid, tableNameBuffer);
-		physicalTableNamesDatum[i++] = (Datum) (cstring_to_text(tableNameBuffer));
+		physicalTableNamesDatum[i++] =
+			(Datum) (cstring_to_text(tableNameBuffer));
 	}
 	UnlockRelationOid(logicalIndexOid, AccessShareLock);
 

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -63,7 +63,7 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 
 	LockRelationOid(logical_index_oid, AccessShareLock);
 	List *physical_index_oids =
-		find_inheritance_children(logical_index_oid, NoLock);
+		find_inheritance_children(logical_index_oid, AccessShareLock);
 	ListCell *cell;
 	Oid physical_index_oid;
 	List *physical_table_names = NIL;

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -72,6 +72,19 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 		PGrnGetLogicalIndexOid(tag, logical_index_name_text);
 
 	LockRelationOid(logical_index_oid, AccessShareLock);
+	/**
+	 * find_inheritance_children() here acquires an AccessShareLock and holds it
+	 * until the end of the transaction. Therefore, the following operations on
+	 * the child tables are blocked during this transaction.
+	 * - DROP TABLE
+	 * - TRUNCATE
+	 * - REINDEX
+	 * - CLUSTER
+	 * - VACUUM FULL
+	 * - REFRESH MATERIALIZED VIEW(not CONCURRENTLY)
+	 * - ALTER INDEX
+	 * - ALTER TABLE
+	 */
 	List *physical_index_oids =
 		find_inheritance_children(logical_index_oid, AccessShareLock);
 	if (!physical_index_oids)

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -5,6 +5,8 @@
 #include "pgrn-physical-table-names.h"
 
 #include <utils/builtins.h>
+#include <storage/lmgr.h>
+#include <catalog/pg_inherits.h>
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_physical_table_names);
 
@@ -55,6 +57,53 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 	const char *tag = "[physical-table-names]";
 	text *logical_index_name_text = PG_GETARG_TEXT_PP(0);
 
-	PGrnGetLogicalIndexOid(tag, logical_index_name_text);
-	PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));
+	Oid logical_index_oid =
+		PGrnGetLogicalIndexOid(tag, logical_index_name_text);
+
+	LockRelationOid(logical_index_oid, AccessShareLock);
+	List *physical_index_oids =
+		find_inheritance_children(logical_index_oid, NoLock);
+	ListCell *cell;
+	Oid physical_index_oid;
+	List *physical_table_names = NIL;
+	char *physical_index_name;
+	char table_name_buffer[GRN_TABLE_MAX_KEY_SIZE];
+	foreach (cell, physical_index_oids)
+	{
+		physical_index_oid = lfirst_oid(cell);
+		if (logical_index_oid == physical_index_oid)
+		{
+			/**
+			 * find_inheritance_children() returns contain parent index oid.
+			 * Therefore, the first element of physical_index_oids skip.
+			 */
+			continue;
+		}
+		physical_index_name = get_rel_name(physical_index_oid);
+		PGrnFormatSourcesTableName(physical_index_name, table_name_buffer);
+		physical_table_names =
+			lappend(physical_table_names,
+					(void *) (cstring_to_text(table_name_buffer)));
+	}
+	UnlockRelationOid(logical_index_oid, AccessShareLock);
+
+	unsigned int n_elements = list_length(physical_table_names);
+	Datum *physical_table_names_datum = palloc(n_elements * sizeof(Datum));
+	unsigned int i = 0;
+	foreach (cell, physical_table_names)
+	{
+		physical_table_names_datum[i++] = (Datum) lfirst(cell);
+	}
+
+	int dims[1] = {n_elements};
+	int lbs[1] = {1};
+	PG_RETURN_ARRAYTYPE_P(construct_md_array(physical_table_names_datum,
+											 NULL,
+											 1,
+											 dims,
+											 lbs,
+											 TEXTOID,
+											 -1,
+											 false,
+											 TYPALIGN_INT));
 }

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -104,14 +104,6 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 	foreach (cell, physicalIndexOids)
 	{
 		physicalIndexOid = lfirst_oid(cell);
-		if (logicalIndexOid == physicalIndexOid)
-		{
-			/**
-			 * find_inheritance_children() returns contain parent index oid.
-			 * Therefore, the first element of physicalIndexOids skip.
-			 */
-			continue;
-		}
 		PGrnGetSourcesTableNameFromOid(physicalIndexOid, tableNameBuffer);
 		physicalTableNames = lappend(
 			physicalTableNames, (void *) (cstring_to_text(tableNameBuffer)));

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -98,7 +98,7 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 		physicalIndexOid = lfirst_oid(cell);
 		PGrnGetSourcesTableNameFromOid(physicalIndexOid, tableNameBuffer);
 		physicalTableNamesDatum[i++] =
-			(Datum) (cstring_to_text(tableNameBuffer));
+			PointerGetDatum(cstring_to_text(tableNameBuffer));
 	}
 	UnlockRelationOid(logicalIndexOid, AccessShareLock);
 

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -7,6 +7,7 @@
 #include <catalog/pg_inherits.h>
 #include <storage/lmgr.h>
 #include <utils/builtins.h>
+#include <utils/lsyscache.h>
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_physical_table_names);
 

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -4,9 +4,9 @@
 #include "pgrn-pg.h"
 #include "pgrn-physical-table-names.h"
 
-#include <utils/builtins.h>
-#include <storage/lmgr.h>
 #include <catalog/pg_inherits.h>
+#include <storage/lmgr.h>
+#include <utils/builtins.h>
 
 PGDLLEXPORT PG_FUNCTION_INFO_V1(pgroonga_physical_table_names);
 

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -89,24 +89,17 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 	ListCell *cell;
 
 	Oid physicalIndexOid;
-	List *physicalTableNames = NIL;
 	char tableNameBuffer[GRN_TABLE_MAX_KEY_SIZE];
+	unsigned int nElements = list_length(physicalIndexOids);
+	Datum *physicalTableNamesDatum = palloc(nElements * sizeof(Datum));
+	unsigned int i = 0;
 	foreach (cell, physicalIndexOids)
 	{
 		physicalIndexOid = lfirst_oid(cell);
 		PGrnGetSourcesTableNameFromOid(physicalIndexOid, tableNameBuffer);
-		physicalTableNames = lappend(
-			physicalTableNames, (void *) (cstring_to_text(tableNameBuffer)));
+		physicalTableNamesDatum[i++] = (Datum) (cstring_to_text(tableNameBuffer));
 	}
 	UnlockRelationOid(logicalIndexOid, AccessShareLock);
-
-	unsigned int nElements = list_length(physicalTableNames);
-	Datum *physicalTableNamesDatum = palloc(nElements * sizeof(Datum));
-	unsigned int i = 0;
-	foreach (cell, physicalTableNames)
-	{
-		physicalTableNamesDatum[i++] = (Datum) lfirst(cell);
-	}
 
 	int dims[1] = {nElements};
 	int lbs[1] = {1};

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -48,16 +48,6 @@ PGrnGetLogicalIndexOid(const char *tag, text *logicalIndexNameText)
 	return logicalIndexOid;
 }
 
-static void
-PGrnGetSourcesTableNameFromOid(Oid oid, char tableName[GRN_TABLE_MAX_KEY_SIZE])
-{
-	Oid fileNodeID = PGrnPGIndexIDToFileNodeID(oid);
-	snprintf(tableName,
-			 GRN_TABLE_MAX_KEY_SIZE,
-			 PGrnSourcesTableNameFormat,
-			 fileNodeID);
-}
-
 /**
  * pgroonga_physical_table_names(logical_index_name text, argument_prefix text)
  * : text[]

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -90,9 +90,9 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 
 	Oid physicalIndexOid;
 	char tableNameBuffer[GRN_TABLE_MAX_KEY_SIZE];
-	unsigned int nElements = list_length(physicalIndexOids);
+	int nElements = list_length(physicalIndexOids);
 	Datum *physicalTableNamesDatum = palloc(nElements * sizeof(Datum));
-	unsigned int i = 0;
+	int i = 0;
 	foreach (cell, physicalIndexOids)
 	{
 		physicalIndexOid = lfirst_oid(cell);

--- a/src/pgrn-physical-table-names.c
+++ b/src/pgrn-physical-table-names.c
@@ -81,7 +81,7 @@ pgroonga_physical_table_names(PG_FUNCTION_ARGS)
 		UnlockRelationOid(logicalIndexOid, AccessShareLock);
 		GRN_LOG(ctx,
 				GRN_LOG_WARNING,
-				"%s <%s> has not children",
+				"%s <%s> has no children",
 				tag,
 				text_to_cstring(logicalIndexNameText));
 		PG_RETURN_ARRAYTYPE_P(construct_empty_array(TEXTOID));


### PR DESCRIPTION
We can get physical table names by executing pgroonga_physical_table_names() when partitions are present.

pgroonga_physical_table_names() acquires an AccessShareLock and holds it until the end of the transaction containing this function.
Therefore, the following operations on the child tables are blocked until the transaction ends.

- DROP TABLE
- TRUNCATE
- REINDEX
- CLUSTER
- VACUUM FULL
- REFRESH MATERIALIZED VIEW(not CONCURRENTLY)
- ALTER INDEX
- ALTER TABLE

However, this change only allows us to get physical table names.
We cannot get the argument prefix yet.
I will implement this feature in a follow-up change.